### PR TITLE
Fix #172: Call the correct method name for autorun INITIAL states

### DIFF
--- a/lib/Workflow/Factory.pm
+++ b/lib/Workflow/Factory.pm
@@ -363,7 +363,7 @@ sub create_workflow {
 
     my $state = $wf->_get_workflow_state();
     if ( $state->autorun ) {
-        my $state_name = $state->name;
+        my $state_name = $state->state;
         $self->log->info( "State '$state_name' marked to be run ",
                           "automatically; executing that state/action..." );
         $wf->_auto_execute_state($state);


### PR DESCRIPTION
# Description

Fixes/addresses (If applicable) #171 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project, please see the [contribution guidelines](https://github.com/jonasbn/perl-workflow/blob/master/CONTRIBUTING.md).
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
