### PR TITLE
Meta data warning

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -56,6 +56,15 @@
 - Workaround for Perls between 5.18 and 5.39.2 clobbering %SIG in Safe->reval()
   which is used internally by `Workflow::Condition::Evaluate`
 
+## 2.02-TRIAL 2024-07-13 TRIAL release, update not required
+
+- Separation of the following classes into separate files, for proper meta-data indexing:
+  - `Workflow::Condition::Result`
+  - `Workflow::Condition::IsTrue`
+  - `Workflow::Condition::IsFalse`
+
+- Added contributors to meta-data (`dist.ini`)
+
 ## 2.01-TRIAL 2024-05-17 TRIAL release, update not required
 
 - See above for changes for version 2.0

--- a/Changes.md
+++ b/Changes.md
@@ -63,8 +63,6 @@
   - `Workflow::Condition::IsTrue`
   - `Workflow::Condition::IsFalse`
 
-- Added contributors to meta-data (`dist.ini`)
-
 ## 2.01-TRIAL 2024-05-17 TRIAL release, update not required
 
 - See above for changes for version 2.0

--- a/cpanfile.snapshot
+++ b/cpanfile.snapshot
@@ -1,0 +1,1926 @@
+# carton snapshot format: version 1.0
+DISTRIBUTIONS
+  AppConfig-1.71
+    pathname: N/NE/NEILB/AppConfig-1.71.tar.gz
+    provides:
+      AppConfig 1.71
+      AppConfig::Args 1.71
+      AppConfig::CGI 1.71
+      AppConfig::File 1.71
+      AppConfig::Getopt 1.71
+      AppConfig::State 1.71
+      AppConfig::Sys 1.71
+    requirements:
+      ExtUtils::MakeMaker 0
+      Test::More 0
+      perl 5.008008
+  B-Hooks-EndOfScope-0.28
+    pathname: E/ET/ETHER/B-Hooks-EndOfScope-0.28.tar.gz
+    provides:
+      B::Hooks::EndOfScope 0.28
+      B::Hooks::EndOfScope::PP 0.28
+      B::Hooks::EndOfScope::XS 0.28
+    requirements:
+      ExtUtils::MakeMaker 0
+      Hash::Util::FieldHash 0
+      Module::Implementation 0.05
+      Scalar::Util 0
+      Sub::Exporter::Progressive 0.001006
+      Text::ParseWords 0
+      Tie::Hash 0
+      Variable::Magic 0.48
+      perl 5.006001
+      strict 0
+      warnings 0
+  CGI-4.65
+    pathname: L/LE/LEEJO/CGI-4.65.tar.gz
+    provides:
+      CGI 4.65
+      CGI::Carp 4.65
+      CGI::Cookie 4.59
+      CGI::File::Temp 4.65
+      CGI::HTML::Functions undef
+      CGI::MultipartBuffer 4.65
+      CGI::Pretty 4.65
+      CGI::Push 4.65
+      CGI::Util 4.65
+      Fh 4.65
+    requirements:
+      Carp 0
+      Config 0
+      Encode 0
+      Exporter 0
+      ExtUtils::MakeMaker 0
+      File::Spec 0.82
+      File::Temp 0.17
+      HTML::Entities 3.69
+      URI 1.76
+      if 0
+      overload 0
+      parent 0.225
+      perl 5.008001
+      strict 0
+      utf8 0
+      warnings 0
+  CPAN-Requirements-Dynamic-0.001
+    pathname: L/LE/LEONT/CPAN-Requirements-Dynamic-0.001.tar.gz
+    provides:
+      CPAN::Requirements::Dynamic 0.001
+    requirements:
+      CPAN::Meta::Prereqs 0
+      CPAN::Meta::Requirements::Range 0
+      Carp 0
+      ExtUtils::Config 0
+      ExtUtils::HasCompiler 0
+      ExtUtils::MakeMaker 0
+      IPC::Cmd 0
+      Module::Metadata 0
+      Parse::CPAN::Meta 0
+      Perl::OSType 0
+      perl 5.006
+      strict 0
+      warnings 0
+  Class-Accessor-0.51
+    pathname: K/KA/KASEI/Class-Accessor-0.51.tar.gz
+    provides:
+      Class::Accessor 0.51
+      Class::Accessor::Fast 0.51
+      Class::Accessor::Faster 0.51
+    requirements:
+      ExtUtils::MakeMaker 0
+      base 1.01
+  Class-Data-Inheritable-0.09
+    pathname: R/RS/RSHERER/Class-Data-Inheritable-0.09.tar.gz
+    provides:
+      Class::Data::Inheritable 0.09
+    requirements:
+      ExtUtils::MakeMaker 0
+  Class-Factory-1.06
+    pathname: P/PH/PHRED/Class-Factory-1.06.tar.gz
+    provides:
+      Class::Factory 1.06
+    requirements:
+      ExtUtils::MakeMaker 0
+  Class-Inspector-1.36
+    pathname: P/PL/PLICEASE/Class-Inspector-1.36.tar.gz
+    provides:
+      Class::Inspector 1.36
+      Class::Inspector::Functions 1.36
+    requirements:
+      ExtUtils::MakeMaker 0
+      File::Spec 0.80
+      base 0
+      perl 5.008
+  Class-Singleton-1.6
+    pathname: S/SH/SHAY/Class-Singleton-1.6.tar.gz
+    provides:
+      Class::Singleton 1.6
+    requirements:
+      ExtUtils::MakeMaker 6.64
+      perl 5.008001
+      strict 0
+      warnings 0
+  Class-Tiny-1.008
+    pathname: D/DA/DAGOLDEN/Class-Tiny-1.008.tar.gz
+    provides:
+      Class::Tiny 1.008
+      Class::Tiny::Object 1.008
+    requirements:
+      Carp 0
+      ExtUtils::MakeMaker 6.17
+      perl 5.006
+      strict 0
+      warnings 0
+  Clone-0.46
+    pathname: G/GA/GARU/Clone-0.46.tar.gz
+    provides:
+      Clone 0.46
+    requirements:
+      ExtUtils::MakeMaker 0
+  DBD-Mock-1.59
+    pathname: J/JL/JLCOOPER/DBD-Mock-1.59.tar.gz
+    provides:
+      DBD::Mock 1.59
+      DBD::Mock::Pool undef
+      DBD::Mock::Pool::db undef
+      DBD::Mock::Session undef
+      DBD::Mock::StatementTrack undef
+      DBD::Mock::StatementTrack::Iterator undef
+      DBD::Mock::db undef
+      DBD::Mock::dr undef
+      DBD::Mock::st undef
+    requirements:
+      DBI 1.3
+      List::Util 1.27
+      Module::Build::Tiny 0.035
+      Test::Exception 0.31
+      Test::More 0.47
+      perl 5.008001
+  DBD-SQLite-1.74
+    pathname: I/IS/ISHIGAKI/DBD-SQLite-1.74.tar.gz
+    provides:
+      DBD::SQLite 1.74
+      DBD::SQLite::Constants undef
+      DBD::SQLite::GetInfo undef
+      DBD::SQLite::VirtualTable 1.74
+      DBD::SQLite::VirtualTable::Cursor 1.74
+      DBD::SQLite::VirtualTable::FileContent undef
+      DBD::SQLite::VirtualTable::FileContent::Cursor undef
+      DBD::SQLite::VirtualTable::PerlData undef
+      DBD::SQLite::VirtualTable::PerlData::Cursor undef
+    requirements:
+      DBI 1.57
+      ExtUtils::MakeMaker 0
+      File::Spec 0.82
+      Test::More 0.88
+      Tie::Hash 0
+      perl 5.006
+  DBI-1.643
+    pathname: T/TI/TIMB/DBI-1.643.tar.gz
+    provides:
+      Bundle::DBI 12.008696
+      DBD::DBM 0.08
+      DBD::DBM::Statement 0.08
+      DBD::DBM::Table 0.08
+      DBD::DBM::db 0.08
+      DBD::DBM::dr 0.08
+      DBD::DBM::st 0.08
+      DBD::ExampleP 12.014311
+      DBD::ExampleP::db 12.014311
+      DBD::ExampleP::dr 12.014311
+      DBD::ExampleP::st 12.014311
+      DBD::File 0.44
+      DBD::File::DataSource::File 0.44
+      DBD::File::DataSource::Stream 0.44
+      DBD::File::Statement 0.44
+      DBD::File::Table 0.44
+      DBD::File::TableSource::FileSystem 0.44
+      DBD::File::db 0.44
+      DBD::File::dr 0.44
+      DBD::File::st 0.44
+      DBD::Gofer 0.015327
+      DBD::Gofer::Policy::Base 0.010088
+      DBD::Gofer::Policy::classic 0.010088
+      DBD::Gofer::Policy::pedantic 0.010088
+      DBD::Gofer::Policy::rush 0.010088
+      DBD::Gofer::Transport::Base 0.014121
+      DBD::Gofer::Transport::corostream undef
+      DBD::Gofer::Transport::null 0.010088
+      DBD::Gofer::Transport::pipeone 0.010088
+      DBD::Gofer::Transport::stream 0.014599
+      DBD::Gofer::db 0.015327
+      DBD::Gofer::dr 0.015327
+      DBD::Gofer::st 0.015327
+      DBD::Mem 0.001
+      DBD::Mem::DataSource 0.001
+      DBD::Mem::Statement 0.001
+      DBD::Mem::Table 0.001
+      DBD::Mem::db 0.001
+      DBD::Mem::dr 0.001
+      DBD::Mem::st 0.001
+      DBD::NullP 12.014715
+      DBD::NullP::db 12.014715
+      DBD::NullP::dr 12.014715
+      DBD::NullP::st 12.014715
+      DBD::Proxy 0.2004
+      DBD::Proxy::RPC::PlClient 0.2004
+      DBD::Proxy::db 0.2004
+      DBD::Proxy::dr 0.2004
+      DBD::Proxy::st 0.2004
+      DBD::Sponge 12.010003
+      DBD::Sponge::db 12.010003
+      DBD::Sponge::dr 12.010003
+      DBD::Sponge::st 12.010003
+      DBDI 12.015129
+      DBI 1.643
+      DBI::Const::GetInfo::ANSI 2.008697
+      DBI::Const::GetInfo::ODBC 2.011374
+      DBI::Const::GetInfoReturn 2.008697
+      DBI::Const::GetInfoType 2.008697
+      DBI::DBD 12.015129
+      DBI::DBD::Metadata 2.014214
+      DBI::DBD::SqlEngine 0.06
+      DBI::DBD::SqlEngine::DataSource 0.06
+      DBI::DBD::SqlEngine::Statement 0.06
+      DBI::DBD::SqlEngine::Table 0.06
+      DBI::DBD::SqlEngine::TableSource 0.06
+      DBI::DBD::SqlEngine::TieMeta 0.06
+      DBI::DBD::SqlEngine::TieTables 0.06
+      DBI::DBD::SqlEngine::db 0.06
+      DBI::DBD::SqlEngine::dr 0.06
+      DBI::DBD::SqlEngine::st 0.06
+      DBI::Gofer::Execute 0.014283
+      DBI::Gofer::Request 0.012537
+      DBI::Gofer::Response 0.011566
+      DBI::Gofer::Serializer::Base 0.009950
+      DBI::Gofer::Serializer::DataDumper 0.009950
+      DBI::Gofer::Serializer::Storable 0.015586
+      DBI::Gofer::Transport::Base 0.012537
+      DBI::Gofer::Transport::pipeone 0.012537
+      DBI::Gofer::Transport::stream 0.012537
+      DBI::Profile 2.015065
+      DBI::ProfileData 2.010008
+      DBI::ProfileDumper 2.015325
+      DBI::ProfileDumper::Apache 2.014121
+      DBI::ProfileSubs 0.009396
+      DBI::ProxyServer 0.3005
+      DBI::ProxyServer::db 0.3005
+      DBI::ProxyServer::dr 0.3005
+      DBI::ProxyServer::st 0.3005
+      DBI::SQL::Nano 1.015544
+      DBI::SQL::Nano::Statement_ 1.015544
+      DBI::SQL::Nano::Table_ 1.015544
+      DBI::Util::CacheMemory 0.010315
+      DBI::Util::_accessor 0.009479
+      DBI::common 1.643
+    requirements:
+      ExtUtils::MakeMaker 6.48
+      Test::Simple 0.90
+      perl 5.008001
+  Data-UUID-1.227
+    pathname: G/GT/GTERMARS/Data-UUID-1.227.tar.gz
+    provides:
+      Data::UUID 1.227
+    requirements:
+      Digest::MD5 0
+      ExtUtils::MakeMaker 0
+  DateTime-1.65
+    pathname: D/DR/DROLSKY/DateTime-1.65.tar.gz
+    provides:
+      DateTime 1.65
+      DateTime::Duration 1.65
+      DateTime::Helpers 1.65
+      DateTime::Infinite 1.65
+      DateTime::Infinite::Future 1.65
+      DateTime::Infinite::Past 1.65
+      DateTime::LeapSecond 1.65
+      DateTime::PP 1.65
+      DateTime::PPExtra 1.65
+      DateTime::Types 1.65
+    requirements:
+      Carp 0
+      DateTime::Locale 1.06
+      DateTime::TimeZone 2.44
+      Dist::CheckConflicts 0.02
+      ExtUtils::MakeMaker 0
+      POSIX 0
+      Params::ValidationCompiler 0.26
+      Scalar::Util 0
+      Specio 0.18
+      Specio::Declare 0
+      Specio::Exporter 0
+      Specio::Library::Builtins 0
+      Specio::Library::Numeric 0
+      Specio::Library::String 0
+      Specio::Subs 0
+      Try::Tiny 0
+      XSLoader 0
+      integer 0
+      namespace::autoclean 0.19
+      overload 0
+      parent 0
+      perl 5.008004
+      strict 0
+      warnings 0
+      warnings::register 0
+  DateTime-Format-Strptime-1.79
+    pathname: D/DR/DROLSKY/DateTime-Format-Strptime-1.79.tar.gz
+    provides:
+      DateTime::Format::Strptime 1.79
+      DateTime::Format::Strptime::Types 1.79
+    requirements:
+      Carp 0
+      DateTime 1.00
+      DateTime::Locale 1.30
+      DateTime::Locale::Base 0
+      DateTime::Locale::FromData 0
+      DateTime::TimeZone 2.09
+      Exporter 0
+      ExtUtils::MakeMaker 0
+      Params::ValidationCompiler 0
+      Specio 0.33
+      Specio::Declare 0
+      Specio::Exporter 0
+      Specio::Library::Builtins 0
+      Specio::Library::String 0
+      Try::Tiny 0
+      constant 0
+      parent 0
+      strict 0
+      warnings 0
+  DateTime-Locale-1.42
+    pathname: D/DR/DROLSKY/DateTime-Locale-1.42.tar.gz
+    provides:
+      DateTime::Locale 1.42
+      DateTime::Locale::Base 1.42
+      DateTime::Locale::Catalog 1.42
+      DateTime::Locale::Data 1.42
+      DateTime::Locale::FromData 1.42
+      DateTime::Locale::Util 1.42
+    requirements:
+      Carp 0
+      Dist::CheckConflicts 0.02
+      Exporter 0
+      ExtUtils::MakeMaker 0
+      File::ShareDir 0
+      File::ShareDir::Install 0.06
+      File::Spec 0
+      List::Util 1.45
+      Params::ValidationCompiler 0.13
+      Specio::Declare 0
+      Specio::Library::String 0
+      Storable 0
+      namespace::autoclean 0.19
+      perl 5.008004
+      strict 0
+      warnings 0
+  DateTime-TimeZone-2.62
+    pathname: D/DR/DROLSKY/DateTime-TimeZone-2.62.tar.gz
+    provides:
+      DateTime::TimeZone 2.62
+      DateTime::TimeZone::Africa::Abidjan 2.62
+      DateTime::TimeZone::Africa::Algiers 2.62
+      DateTime::TimeZone::Africa::Bissau 2.62
+      DateTime::TimeZone::Africa::Cairo 2.62
+      DateTime::TimeZone::Africa::Casablanca 2.62
+      DateTime::TimeZone::Africa::Ceuta 2.62
+      DateTime::TimeZone::Africa::El_Aaiun 2.62
+      DateTime::TimeZone::Africa::Johannesburg 2.62
+      DateTime::TimeZone::Africa::Juba 2.62
+      DateTime::TimeZone::Africa::Khartoum 2.62
+      DateTime::TimeZone::Africa::Lagos 2.62
+      DateTime::TimeZone::Africa::Maputo 2.62
+      DateTime::TimeZone::Africa::Monrovia 2.62
+      DateTime::TimeZone::Africa::Nairobi 2.62
+      DateTime::TimeZone::Africa::Ndjamena 2.62
+      DateTime::TimeZone::Africa::Sao_Tome 2.62
+      DateTime::TimeZone::Africa::Tripoli 2.62
+      DateTime::TimeZone::Africa::Tunis 2.62
+      DateTime::TimeZone::Africa::Windhoek 2.62
+      DateTime::TimeZone::America::Adak 2.62
+      DateTime::TimeZone::America::Anchorage 2.62
+      DateTime::TimeZone::America::Araguaina 2.62
+      DateTime::TimeZone::America::Argentina::Buenos_Aires 2.62
+      DateTime::TimeZone::America::Argentina::Catamarca 2.62
+      DateTime::TimeZone::America::Argentina::Cordoba 2.62
+      DateTime::TimeZone::America::Argentina::Jujuy 2.62
+      DateTime::TimeZone::America::Argentina::La_Rioja 2.62
+      DateTime::TimeZone::America::Argentina::Mendoza 2.62
+      DateTime::TimeZone::America::Argentina::Rio_Gallegos 2.62
+      DateTime::TimeZone::America::Argentina::Salta 2.62
+      DateTime::TimeZone::America::Argentina::San_Juan 2.62
+      DateTime::TimeZone::America::Argentina::San_Luis 2.62
+      DateTime::TimeZone::America::Argentina::Tucuman 2.62
+      DateTime::TimeZone::America::Argentina::Ushuaia 2.62
+      DateTime::TimeZone::America::Asuncion 2.62
+      DateTime::TimeZone::America::Bahia 2.62
+      DateTime::TimeZone::America::Bahia_Banderas 2.62
+      DateTime::TimeZone::America::Barbados 2.62
+      DateTime::TimeZone::America::Belem 2.62
+      DateTime::TimeZone::America::Belize 2.62
+      DateTime::TimeZone::America::Boa_Vista 2.62
+      DateTime::TimeZone::America::Bogota 2.62
+      DateTime::TimeZone::America::Boise 2.62
+      DateTime::TimeZone::America::Cambridge_Bay 2.62
+      DateTime::TimeZone::America::Campo_Grande 2.62
+      DateTime::TimeZone::America::Cancun 2.62
+      DateTime::TimeZone::America::Caracas 2.62
+      DateTime::TimeZone::America::Cayenne 2.62
+      DateTime::TimeZone::America::Chicago 2.62
+      DateTime::TimeZone::America::Chihuahua 2.62
+      DateTime::TimeZone::America::Ciudad_Juarez 2.62
+      DateTime::TimeZone::America::Costa_Rica 2.62
+      DateTime::TimeZone::America::Cuiaba 2.62
+      DateTime::TimeZone::America::Danmarkshavn 2.62
+      DateTime::TimeZone::America::Dawson 2.62
+      DateTime::TimeZone::America::Dawson_Creek 2.62
+      DateTime::TimeZone::America::Denver 2.62
+      DateTime::TimeZone::America::Detroit 2.62
+      DateTime::TimeZone::America::Edmonton 2.62
+      DateTime::TimeZone::America::Eirunepe 2.62
+      DateTime::TimeZone::America::El_Salvador 2.62
+      DateTime::TimeZone::America::Fort_Nelson 2.62
+      DateTime::TimeZone::America::Fortaleza 2.62
+      DateTime::TimeZone::America::Glace_Bay 2.62
+      DateTime::TimeZone::America::Goose_Bay 2.62
+      DateTime::TimeZone::America::Grand_Turk 2.62
+      DateTime::TimeZone::America::Guatemala 2.62
+      DateTime::TimeZone::America::Guayaquil 2.62
+      DateTime::TimeZone::America::Guyana 2.62
+      DateTime::TimeZone::America::Halifax 2.62
+      DateTime::TimeZone::America::Havana 2.62
+      DateTime::TimeZone::America::Hermosillo 2.62
+      DateTime::TimeZone::America::Indiana::Indianapolis 2.62
+      DateTime::TimeZone::America::Indiana::Knox 2.62
+      DateTime::TimeZone::America::Indiana::Marengo 2.62
+      DateTime::TimeZone::America::Indiana::Petersburg 2.62
+      DateTime::TimeZone::America::Indiana::Tell_City 2.62
+      DateTime::TimeZone::America::Indiana::Vevay 2.62
+      DateTime::TimeZone::America::Indiana::Vincennes 2.62
+      DateTime::TimeZone::America::Indiana::Winamac 2.62
+      DateTime::TimeZone::America::Inuvik 2.62
+      DateTime::TimeZone::America::Iqaluit 2.62
+      DateTime::TimeZone::America::Jamaica 2.62
+      DateTime::TimeZone::America::Juneau 2.62
+      DateTime::TimeZone::America::Kentucky::Louisville 2.62
+      DateTime::TimeZone::America::Kentucky::Monticello 2.62
+      DateTime::TimeZone::America::La_Paz 2.62
+      DateTime::TimeZone::America::Lima 2.62
+      DateTime::TimeZone::America::Los_Angeles 2.62
+      DateTime::TimeZone::America::Maceio 2.62
+      DateTime::TimeZone::America::Managua 2.62
+      DateTime::TimeZone::America::Manaus 2.62
+      DateTime::TimeZone::America::Martinique 2.62
+      DateTime::TimeZone::America::Matamoros 2.62
+      DateTime::TimeZone::America::Mazatlan 2.62
+      DateTime::TimeZone::America::Menominee 2.62
+      DateTime::TimeZone::America::Merida 2.62
+      DateTime::TimeZone::America::Metlakatla 2.62
+      DateTime::TimeZone::America::Mexico_City 2.62
+      DateTime::TimeZone::America::Miquelon 2.62
+      DateTime::TimeZone::America::Moncton 2.62
+      DateTime::TimeZone::America::Monterrey 2.62
+      DateTime::TimeZone::America::Montevideo 2.62
+      DateTime::TimeZone::America::New_York 2.62
+      DateTime::TimeZone::America::Nome 2.62
+      DateTime::TimeZone::America::Noronha 2.62
+      DateTime::TimeZone::America::North_Dakota::Beulah 2.62
+      DateTime::TimeZone::America::North_Dakota::Center 2.62
+      DateTime::TimeZone::America::North_Dakota::New_Salem 2.62
+      DateTime::TimeZone::America::Nuuk 2.62
+      DateTime::TimeZone::America::Ojinaga 2.62
+      DateTime::TimeZone::America::Panama 2.62
+      DateTime::TimeZone::America::Paramaribo 2.62
+      DateTime::TimeZone::America::Phoenix 2.62
+      DateTime::TimeZone::America::Port_au_Prince 2.62
+      DateTime::TimeZone::America::Porto_Velho 2.62
+      DateTime::TimeZone::America::Puerto_Rico 2.62
+      DateTime::TimeZone::America::Punta_Arenas 2.62
+      DateTime::TimeZone::America::Rankin_Inlet 2.62
+      DateTime::TimeZone::America::Recife 2.62
+      DateTime::TimeZone::America::Regina 2.62
+      DateTime::TimeZone::America::Resolute 2.62
+      DateTime::TimeZone::America::Rio_Branco 2.62
+      DateTime::TimeZone::America::Santarem 2.62
+      DateTime::TimeZone::America::Santiago 2.62
+      DateTime::TimeZone::America::Santo_Domingo 2.62
+      DateTime::TimeZone::America::Sao_Paulo 2.62
+      DateTime::TimeZone::America::Scoresbysund 2.62
+      DateTime::TimeZone::America::Sitka 2.62
+      DateTime::TimeZone::America::St_Johns 2.62
+      DateTime::TimeZone::America::Swift_Current 2.62
+      DateTime::TimeZone::America::Tegucigalpa 2.62
+      DateTime::TimeZone::America::Thule 2.62
+      DateTime::TimeZone::America::Tijuana 2.62
+      DateTime::TimeZone::America::Toronto 2.62
+      DateTime::TimeZone::America::Vancouver 2.62
+      DateTime::TimeZone::America::Whitehorse 2.62
+      DateTime::TimeZone::America::Winnipeg 2.62
+      DateTime::TimeZone::America::Yakutat 2.62
+      DateTime::TimeZone::Antarctica::Casey 2.62
+      DateTime::TimeZone::Antarctica::Davis 2.62
+      DateTime::TimeZone::Antarctica::Macquarie 2.62
+      DateTime::TimeZone::Antarctica::Mawson 2.62
+      DateTime::TimeZone::Antarctica::Palmer 2.62
+      DateTime::TimeZone::Antarctica::Rothera 2.62
+      DateTime::TimeZone::Antarctica::Troll 2.62
+      DateTime::TimeZone::Antarctica::Vostok 2.62
+      DateTime::TimeZone::Asia::Almaty 2.62
+      DateTime::TimeZone::Asia::Amman 2.62
+      DateTime::TimeZone::Asia::Anadyr 2.62
+      DateTime::TimeZone::Asia::Aqtau 2.62
+      DateTime::TimeZone::Asia::Aqtobe 2.62
+      DateTime::TimeZone::Asia::Ashgabat 2.62
+      DateTime::TimeZone::Asia::Atyrau 2.62
+      DateTime::TimeZone::Asia::Baghdad 2.62
+      DateTime::TimeZone::Asia::Baku 2.62
+      DateTime::TimeZone::Asia::Bangkok 2.62
+      DateTime::TimeZone::Asia::Barnaul 2.62
+      DateTime::TimeZone::Asia::Beirut 2.62
+      DateTime::TimeZone::Asia::Bishkek 2.62
+      DateTime::TimeZone::Asia::Chita 2.62
+      DateTime::TimeZone::Asia::Choibalsan 2.62
+      DateTime::TimeZone::Asia::Colombo 2.62
+      DateTime::TimeZone::Asia::Damascus 2.62
+      DateTime::TimeZone::Asia::Dhaka 2.62
+      DateTime::TimeZone::Asia::Dili 2.62
+      DateTime::TimeZone::Asia::Dubai 2.62
+      DateTime::TimeZone::Asia::Dushanbe 2.62
+      DateTime::TimeZone::Asia::Famagusta 2.62
+      DateTime::TimeZone::Asia::Gaza 2.62
+      DateTime::TimeZone::Asia::Hebron 2.62
+      DateTime::TimeZone::Asia::Ho_Chi_Minh 2.62
+      DateTime::TimeZone::Asia::Hong_Kong 2.62
+      DateTime::TimeZone::Asia::Hovd 2.62
+      DateTime::TimeZone::Asia::Irkutsk 2.62
+      DateTime::TimeZone::Asia::Jakarta 2.62
+      DateTime::TimeZone::Asia::Jayapura 2.62
+      DateTime::TimeZone::Asia::Jerusalem 2.62
+      DateTime::TimeZone::Asia::Kabul 2.62
+      DateTime::TimeZone::Asia::Kamchatka 2.62
+      DateTime::TimeZone::Asia::Karachi 2.62
+      DateTime::TimeZone::Asia::Kathmandu 2.62
+      DateTime::TimeZone::Asia::Khandyga 2.62
+      DateTime::TimeZone::Asia::Kolkata 2.62
+      DateTime::TimeZone::Asia::Krasnoyarsk 2.62
+      DateTime::TimeZone::Asia::Kuching 2.62
+      DateTime::TimeZone::Asia::Macau 2.62
+      DateTime::TimeZone::Asia::Magadan 2.62
+      DateTime::TimeZone::Asia::Makassar 2.62
+      DateTime::TimeZone::Asia::Manila 2.62
+      DateTime::TimeZone::Asia::Nicosia 2.62
+      DateTime::TimeZone::Asia::Novokuznetsk 2.62
+      DateTime::TimeZone::Asia::Novosibirsk 2.62
+      DateTime::TimeZone::Asia::Omsk 2.62
+      DateTime::TimeZone::Asia::Oral 2.62
+      DateTime::TimeZone::Asia::Pontianak 2.62
+      DateTime::TimeZone::Asia::Pyongyang 2.62
+      DateTime::TimeZone::Asia::Qatar 2.62
+      DateTime::TimeZone::Asia::Qostanay 2.62
+      DateTime::TimeZone::Asia::Qyzylorda 2.62
+      DateTime::TimeZone::Asia::Riyadh 2.62
+      DateTime::TimeZone::Asia::Sakhalin 2.62
+      DateTime::TimeZone::Asia::Samarkand 2.62
+      DateTime::TimeZone::Asia::Seoul 2.62
+      DateTime::TimeZone::Asia::Shanghai 2.62
+      DateTime::TimeZone::Asia::Singapore 2.62
+      DateTime::TimeZone::Asia::Srednekolymsk 2.62
+      DateTime::TimeZone::Asia::Taipei 2.62
+      DateTime::TimeZone::Asia::Tashkent 2.62
+      DateTime::TimeZone::Asia::Tbilisi 2.62
+      DateTime::TimeZone::Asia::Tehran 2.62
+      DateTime::TimeZone::Asia::Thimphu 2.62
+      DateTime::TimeZone::Asia::Tokyo 2.62
+      DateTime::TimeZone::Asia::Tomsk 2.62
+      DateTime::TimeZone::Asia::Ulaanbaatar 2.62
+      DateTime::TimeZone::Asia::Urumqi 2.62
+      DateTime::TimeZone::Asia::Ust_Nera 2.62
+      DateTime::TimeZone::Asia::Vladivostok 2.62
+      DateTime::TimeZone::Asia::Yakutsk 2.62
+      DateTime::TimeZone::Asia::Yangon 2.62
+      DateTime::TimeZone::Asia::Yekaterinburg 2.62
+      DateTime::TimeZone::Asia::Yerevan 2.62
+      DateTime::TimeZone::Atlantic::Azores 2.62
+      DateTime::TimeZone::Atlantic::Bermuda 2.62
+      DateTime::TimeZone::Atlantic::Canary 2.62
+      DateTime::TimeZone::Atlantic::Cape_Verde 2.62
+      DateTime::TimeZone::Atlantic::Faroe 2.62
+      DateTime::TimeZone::Atlantic::Madeira 2.62
+      DateTime::TimeZone::Atlantic::South_Georgia 2.62
+      DateTime::TimeZone::Atlantic::Stanley 2.62
+      DateTime::TimeZone::Australia::Adelaide 2.62
+      DateTime::TimeZone::Australia::Brisbane 2.62
+      DateTime::TimeZone::Australia::Broken_Hill 2.62
+      DateTime::TimeZone::Australia::Darwin 2.62
+      DateTime::TimeZone::Australia::Eucla 2.62
+      DateTime::TimeZone::Australia::Hobart 2.62
+      DateTime::TimeZone::Australia::Lindeman 2.62
+      DateTime::TimeZone::Australia::Lord_Howe 2.62
+      DateTime::TimeZone::Australia::Melbourne 2.62
+      DateTime::TimeZone::Australia::Perth 2.62
+      DateTime::TimeZone::Australia::Sydney 2.62
+      DateTime::TimeZone::CET 2.62
+      DateTime::TimeZone::CST6CDT 2.62
+      DateTime::TimeZone::Catalog 2.62
+      DateTime::TimeZone::EET 2.62
+      DateTime::TimeZone::EST 2.62
+      DateTime::TimeZone::EST5EDT 2.62
+      DateTime::TimeZone::Europe::Andorra 2.62
+      DateTime::TimeZone::Europe::Astrakhan 2.62
+      DateTime::TimeZone::Europe::Athens 2.62
+      DateTime::TimeZone::Europe::Belgrade 2.62
+      DateTime::TimeZone::Europe::Berlin 2.62
+      DateTime::TimeZone::Europe::Brussels 2.62
+      DateTime::TimeZone::Europe::Bucharest 2.62
+      DateTime::TimeZone::Europe::Budapest 2.62
+      DateTime::TimeZone::Europe::Chisinau 2.62
+      DateTime::TimeZone::Europe::Dublin 2.62
+      DateTime::TimeZone::Europe::Gibraltar 2.62
+      DateTime::TimeZone::Europe::Helsinki 2.62
+      DateTime::TimeZone::Europe::Istanbul 2.62
+      DateTime::TimeZone::Europe::Kaliningrad 2.62
+      DateTime::TimeZone::Europe::Kirov 2.62
+      DateTime::TimeZone::Europe::Kyiv 2.62
+      DateTime::TimeZone::Europe::Lisbon 2.62
+      DateTime::TimeZone::Europe::London 2.62
+      DateTime::TimeZone::Europe::Madrid 2.62
+      DateTime::TimeZone::Europe::Malta 2.62
+      DateTime::TimeZone::Europe::Minsk 2.62
+      DateTime::TimeZone::Europe::Moscow 2.62
+      DateTime::TimeZone::Europe::Paris 2.62
+      DateTime::TimeZone::Europe::Prague 2.62
+      DateTime::TimeZone::Europe::Riga 2.62
+      DateTime::TimeZone::Europe::Rome 2.62
+      DateTime::TimeZone::Europe::Samara 2.62
+      DateTime::TimeZone::Europe::Saratov 2.62
+      DateTime::TimeZone::Europe::Simferopol 2.62
+      DateTime::TimeZone::Europe::Sofia 2.62
+      DateTime::TimeZone::Europe::Tallinn 2.62
+      DateTime::TimeZone::Europe::Tirane 2.62
+      DateTime::TimeZone::Europe::Ulyanovsk 2.62
+      DateTime::TimeZone::Europe::Vienna 2.62
+      DateTime::TimeZone::Europe::Vilnius 2.62
+      DateTime::TimeZone::Europe::Volgograd 2.62
+      DateTime::TimeZone::Europe::Warsaw 2.62
+      DateTime::TimeZone::Europe::Zurich 2.62
+      DateTime::TimeZone::Floating 2.62
+      DateTime::TimeZone::HST 2.62
+      DateTime::TimeZone::Indian::Chagos 2.62
+      DateTime::TimeZone::Indian::Maldives 2.62
+      DateTime::TimeZone::Indian::Mauritius 2.62
+      DateTime::TimeZone::Local 2.62
+      DateTime::TimeZone::Local::Android 2.62
+      DateTime::TimeZone::Local::Unix 2.62
+      DateTime::TimeZone::Local::VMS 2.62
+      DateTime::TimeZone::MET 2.62
+      DateTime::TimeZone::MST 2.62
+      DateTime::TimeZone::MST7MDT 2.62
+      DateTime::TimeZone::OffsetOnly 2.62
+      DateTime::TimeZone::OlsonDB 2.62
+      DateTime::TimeZone::OlsonDB::Change 2.62
+      DateTime::TimeZone::OlsonDB::Observance 2.62
+      DateTime::TimeZone::OlsonDB::Rule 2.62
+      DateTime::TimeZone::OlsonDB::Zone 2.62
+      DateTime::TimeZone::PST8PDT 2.62
+      DateTime::TimeZone::Pacific::Apia 2.62
+      DateTime::TimeZone::Pacific::Auckland 2.62
+      DateTime::TimeZone::Pacific::Bougainville 2.62
+      DateTime::TimeZone::Pacific::Chatham 2.62
+      DateTime::TimeZone::Pacific::Easter 2.62
+      DateTime::TimeZone::Pacific::Efate 2.62
+      DateTime::TimeZone::Pacific::Fakaofo 2.62
+      DateTime::TimeZone::Pacific::Fiji 2.62
+      DateTime::TimeZone::Pacific::Galapagos 2.62
+      DateTime::TimeZone::Pacific::Gambier 2.62
+      DateTime::TimeZone::Pacific::Guadalcanal 2.62
+      DateTime::TimeZone::Pacific::Guam 2.62
+      DateTime::TimeZone::Pacific::Honolulu 2.62
+      DateTime::TimeZone::Pacific::Kanton 2.62
+      DateTime::TimeZone::Pacific::Kiritimati 2.62
+      DateTime::TimeZone::Pacific::Kosrae 2.62
+      DateTime::TimeZone::Pacific::Kwajalein 2.62
+      DateTime::TimeZone::Pacific::Marquesas 2.62
+      DateTime::TimeZone::Pacific::Nauru 2.62
+      DateTime::TimeZone::Pacific::Niue 2.62
+      DateTime::TimeZone::Pacific::Norfolk 2.62
+      DateTime::TimeZone::Pacific::Noumea 2.62
+      DateTime::TimeZone::Pacific::Pago_Pago 2.62
+      DateTime::TimeZone::Pacific::Palau 2.62
+      DateTime::TimeZone::Pacific::Pitcairn 2.62
+      DateTime::TimeZone::Pacific::Port_Moresby 2.62
+      DateTime::TimeZone::Pacific::Rarotonga 2.62
+      DateTime::TimeZone::Pacific::Tahiti 2.62
+      DateTime::TimeZone::Pacific::Tarawa 2.62
+      DateTime::TimeZone::Pacific::Tongatapu 2.62
+      DateTime::TimeZone::UTC 2.62
+      DateTime::TimeZone::WET 2.62
+    requirements:
+      Class::Singleton 1.03
+      Cwd 3
+      ExtUtils::MakeMaker 0
+      File::Basename 0
+      File::Compare 0
+      File::Find 0
+      File::Spec 0
+      List::Util 1.33
+      Module::Runtime 0
+      Params::ValidationCompiler 0.13
+      Specio::Library::Builtins 0
+      Specio::Library::String 0
+      Try::Tiny 0
+      constant 0
+      namespace::autoclean 0
+      parent 0
+      perl 5.008004
+      strict 0
+      warnings 0
+  Devel-StackTrace-2.05
+    pathname: D/DR/DROLSKY/Devel-StackTrace-2.05.tar.gz
+    provides:
+      Devel::StackTrace 2.05
+      Devel::StackTrace::Frame 2.05
+    requirements:
+      ExtUtils::MakeMaker 0
+      File::Spec 0
+      Scalar::Util 0
+      overload 0
+      perl 5.006
+      strict 0
+      warnings 0
+  Dist-CheckConflicts-0.11
+    pathname: D/DO/DOY/Dist-CheckConflicts-0.11.tar.gz
+    provides:
+      Dist::CheckConflicts 0.11
+    requirements:
+      Carp 0
+      Exporter 0
+      ExtUtils::MakeMaker 6.30
+      Module::Runtime 0.009
+      base 0
+      strict 0
+      warnings 0
+  Encode-Locale-1.05
+    pathname: G/GA/GAAS/Encode-Locale-1.05.tar.gz
+    provides:
+      Encode::Locale 1.05
+    requirements:
+      Encode 2
+      Encode::Alias 0
+      ExtUtils::MakeMaker 0
+      perl 5.008
+  Eval-Closure-0.14
+    pathname: D/DO/DOY/Eval-Closure-0.14.tar.gz
+    provides:
+      Eval::Closure 0.14
+    requirements:
+      Carp 0
+      Exporter 0
+      ExtUtils::MakeMaker 0
+      Scalar::Util 0
+      constant 0
+      overload 0
+      strict 0
+      warnings 0
+  Exception-Class-1.45
+    pathname: D/DR/DROLSKY/Exception-Class-1.45.tar.gz
+    provides:
+      Exception::Class 1.45
+      Exception::Class::Base 1.45
+    requirements:
+      Carp 0
+      Class::Data::Inheritable 0.02
+      Devel::StackTrace 2.00
+      ExtUtils::MakeMaker 0
+      Scalar::Util 0
+      base 0
+      overload 0
+      perl 5.008001
+      strict 0
+      warnings 0
+  Exporter-Tiny-1.006002
+    pathname: T/TO/TOBYINK/Exporter-Tiny-1.006002.tar.gz
+    provides:
+      Exporter::Shiny 1.006002
+      Exporter::Tiny 1.006002
+    requirements:
+      ExtUtils::MakeMaker 6.17
+      perl 5.006001
+  ExtUtils-CChecker-0.12
+    pathname: P/PE/PEVANS/ExtUtils-CChecker-0.12.tar.gz
+    provides:
+      ExtUtils::CChecker 0.12
+    requirements:
+      ExtUtils::CBuilder 0
+      Module::Build 0.4004
+      perl 5.014
+  ExtUtils-Config-0.009
+    pathname: L/LE/LEONT/ExtUtils-Config-0.009.tar.gz
+    provides:
+      ExtUtils::Config 0.009
+      ExtUtils::Config::MakeMaker 0.009
+    requirements:
+      Data::Dumper 0
+      ExtUtils::MakeMaker 0
+      ExtUtils::MakeMaker::Config 0
+      perl 5.006
+      strict 0
+      warnings 0
+  ExtUtils-HasCompiler-0.025
+    pathname: L/LE/LEONT/ExtUtils-HasCompiler-0.025.tar.gz
+    provides:
+      ExtUtils::HasCompiler 0.025
+    requirements:
+      Carp 0
+      DynaLoader 0
+      Exporter 0
+      ExtUtils::MakeMaker 0
+      ExtUtils::Mksymlists 0
+      File::Basename 0
+      File::Spec::Functions 0
+      File::Temp 0
+      base 0
+      perl 5.006
+      strict 0
+      warnings 0
+  ExtUtils-Helpers-0.026
+    pathname: L/LE/LEONT/ExtUtils-Helpers-0.026.tar.gz
+    provides:
+      ExtUtils::Helpers 0.026
+      ExtUtils::Helpers::Unix 0.026
+      ExtUtils::Helpers::VMS 0.026
+      ExtUtils::Helpers::Windows 0.026
+    requirements:
+      Carp 0
+      Exporter 5.57
+      ExtUtils::MakeMaker 0
+      File::Basename 0
+      File::Copy 0
+      File::Spec::Functions 0
+      Text::ParseWords 3.24
+      perl 5.006
+      strict 0
+      warnings 0
+  ExtUtils-InstallPaths-0.013
+    pathname: L/LE/LEONT/ExtUtils-InstallPaths-0.013.tar.gz
+    provides:
+      ExtUtils::InstallPaths 0.013
+    requirements:
+      Carp 0
+      ExtUtils::Config 0.002
+      ExtUtils::MakeMaker 0
+      File::Spec 0
+      perl 5.006
+      strict 0
+      warnings 0
+  File-Listing-6.16
+    pathname: P/PL/PLICEASE/File-Listing-6.16.tar.gz
+    provides:
+      File::Listing 6.16
+      File::Listing::apache 6.16
+      File::Listing::dosftp 6.16
+      File::Listing::netware 6.16
+      File::Listing::unix 6.16
+      File::Listing::vms 6.16
+    requirements:
+      Exporter 5.57
+      ExtUtils::MakeMaker 0
+      HTTP::Date 0
+      perl 5.006
+  File-ShareDir-1.118
+    pathname: R/RE/REHSACK/File-ShareDir-1.118.tar.gz
+    provides:
+      File::ShareDir 1.118
+    requirements:
+      Carp 0
+      Class::Inspector 1.12
+      ExtUtils::MakeMaker 0
+      File::ShareDir::Install 0.13
+      File::Spec 0.80
+      perl 5.008001
+      warnings 0
+  File-ShareDir-Install-0.14
+    pathname: E/ET/ETHER/File-ShareDir-Install-0.14.tar.gz
+    provides:
+      File::ShareDir::Install 0.14
+    requirements:
+      Carp 0
+      Exporter 0
+      ExtUtils::MakeMaker 0
+      File::Spec 0
+      IO::Dir 0
+      perl 5.006
+      strict 0
+      warnings 0
+  File-Slurp-9999.32
+    pathname: C/CA/CAPOEIRAB/File-Slurp-9999.32.tar.gz
+    provides:
+      File::Slurp 9999.32
+    requirements:
+      B 0
+      Carp 0
+      Errno 0
+      Exporter 5.57
+      ExtUtils::MakeMaker 0
+      Fcntl 0
+      File::Basename 0
+      File::Spec 3.01
+      File::Temp 0
+      IO::Handle 0
+      POSIX 0
+      strict 0
+      warnings 0
+  HTML-Parser-3.82
+    pathname: O/OA/OALDERS/HTML-Parser-3.82.tar.gz
+    provides:
+      HTML::Entities 3.82
+      HTML::Filter 3.82
+      HTML::HeadParser 3.82
+      HTML::LinkExtor 3.82
+      HTML::Parser 3.82
+      HTML::PullParser 3.82
+      HTML::TokeParser 3.82
+    requirements:
+      Carp 0
+      Exporter 0
+      ExtUtils::MakeMaker 6.52
+      HTML::Tagset 0
+      HTTP::Headers 0
+      IO::File 0
+      URI 0
+      URI::URL 0
+      XSLoader 0
+      strict 0
+  HTML-Tagset-3.24
+    pathname: P/PE/PETDANCE/HTML-Tagset-3.24.tar.gz
+    provides:
+      HTML::Tagset 3.24
+    requirements:
+      ExtUtils::MakeMaker 6.46
+      perl 5.010001
+  HTTP-Cookies-6.11
+    pathname: O/OA/OALDERS/HTTP-Cookies-6.11.tar.gz
+    provides:
+      HTTP::Cookies 6.11
+      HTTP::Cookies::Microsoft 6.11
+      HTTP::Cookies::Netscape 6.11
+    requirements:
+      Carp 0
+      ExtUtils::MakeMaker 0
+      HTTP::Date 6
+      HTTP::Headers::Util 6
+      HTTP::Request 0
+      locale 0
+      perl 5.008001
+      strict 0
+  HTTP-Daemon-6.16
+    pathname: O/OA/OALDERS/HTTP-Daemon-6.16.tar.gz
+    provides:
+      HTTP::Daemon 6.16
+    requirements:
+      Carp 0
+      ExtUtils::MakeMaker 0
+      HTTP::Date 6
+      HTTP::Request 6
+      HTTP::Response 6
+      HTTP::Status 6
+      IO::Socket::IP 0.32
+      LWP::MediaTypes 6
+      Module::Build::Tiny 0.034
+      Socket 0
+      perl 5.006
+      strict 0
+      warnings 0
+  HTTP-Date-6.06
+    pathname: O/OA/OALDERS/HTTP-Date-6.06.tar.gz
+    provides:
+      HTTP::Date 6.06
+    requirements:
+      Exporter 0
+      ExtUtils::MakeMaker 0
+      Time::Local 1.28
+      Time::Zone 0
+      perl 5.006002
+      strict 0
+  HTTP-Message-6.46
+    pathname: O/OA/OALDERS/HTTP-Message-6.46.tar.gz
+    provides:
+      HTTP::Config 6.46
+      HTTP::Headers 6.46
+      HTTP::Headers::Auth 6.46
+      HTTP::Headers::ETag 6.46
+      HTTP::Headers::Util 6.46
+      HTTP::Message 6.46
+      HTTP::Request 6.46
+      HTTP::Request::Common 6.46
+      HTTP::Response 6.46
+      HTTP::Status 6.46
+    requirements:
+      Carp 0
+      Clone 0.46
+      Compress::Raw::Bzip2 0
+      Compress::Raw::Zlib 2.062
+      Encode 3.01
+      Encode::Locale 1
+      Exporter 5.57
+      ExtUtils::MakeMaker 0
+      File::Spec 0
+      HTTP::Date 6
+      IO::Compress::Bzip2 2.021
+      IO::Compress::Deflate 0
+      IO::Compress::Gzip 0
+      IO::HTML 0
+      IO::Uncompress::Inflate 0
+      IO::Uncompress::RawInflate 0
+      LWP::MediaTypes 6
+      MIME::Base64 2.1
+      MIME::QuotedPrint 0
+      URI 1.10
+      parent 0
+      perl 5.008001
+      strict 0
+      warnings 0
+  HTTP-Negotiate-6.01
+    pathname: G/GA/GAAS/HTTP-Negotiate-6.01.tar.gz
+    provides:
+      HTTP::Negotiate 6.01
+    requirements:
+      ExtUtils::MakeMaker 0
+      HTTP::Headers 6
+      perl 5.008001
+  IO-HTML-1.004
+    pathname: C/CJ/CJM/IO-HTML-1.004.tar.gz
+    provides:
+      IO::HTML 1.004
+    requirements:
+      Carp 0
+      Encode 2.10
+      Exporter 5.57
+      ExtUtils::MakeMaker 0
+      perl 5.008
+  LWP-MediaTypes-6.04
+    pathname: O/OA/OALDERS/LWP-MediaTypes-6.04.tar.gz
+    provides:
+      LWP::MediaTypes 6.04
+    requirements:
+      Carp 0
+      Exporter 0
+      ExtUtils::MakeMaker 0
+      File::Basename 0
+      Scalar::Util 0
+      perl 5.006002
+      strict 0
+  List-MoreUtils-0.430
+    pathname: R/RE/REHSACK/List-MoreUtils-0.430.tar.gz
+    provides:
+      List::MoreUtils 0.430
+      List::MoreUtils::PP 0.430
+    requirements:
+      Exporter::Tiny 0.038
+      ExtUtils::MakeMaker 0
+      List::MoreUtils::XS 0.430
+  List-MoreUtils-XS-0.430
+    pathname: R/RE/REHSACK/List-MoreUtils-XS-0.430.tar.gz
+    provides:
+      List::MoreUtils::XS 0.430
+    requirements:
+      Carp 0
+      ExtUtils::MakeMaker 0
+      File::Basename 0
+      File::Copy 0
+      File::Path 0
+      File::Spec 0
+      IPC::Cmd 0
+      XSLoader 0.22
+      base 0
+  Log-Any-1.717
+    pathname: P/PR/PREACTION/Log-Any-1.717.tar.gz
+    provides:
+      Log::Any 1.717
+      Log::Any::Adapter 1.717
+      Log::Any::Adapter::Base 1.717
+      Log::Any::Adapter::Capture 1.717
+      Log::Any::Adapter::File 1.717
+      Log::Any::Adapter::Multiplex 1.717
+      Log::Any::Adapter::Null 1.717
+      Log::Any::Adapter::Stderr 1.717
+      Log::Any::Adapter::Stdout 1.717
+      Log::Any::Adapter::Syslog 1.717
+      Log::Any::Adapter::Test 1.717
+      Log::Any::Adapter::Util 1.717
+      Log::Any::Manager 1.717
+      Log::Any::Proxy 1.717
+      Log::Any::Proxy::Null 1.717
+      Log::Any::Proxy::Test 1.717
+      Log::Any::Proxy::WithStackTrace 1.717
+      Log::Any::Test 1.717
+    requirements:
+      ExtUtils::MakeMaker 0
+  MRO-Compat-0.15
+    pathname: H/HA/HAARG/MRO-Compat-0.15.tar.gz
+    provides:
+      MRO::Compat 0.15
+    requirements:
+      ExtUtils::MakeMaker 0
+      perl 5.006
+  Mock-MonkeyPatch-1.02
+    pathname: J/JB/JBERGER/Mock-MonkeyPatch-1.02.tar.gz
+    provides:
+      Mock::MonkeyPatch 1.02
+    requirements:
+      Module::Build::Tiny 0.034
+      Sub::Util 1.40
+  Module-Build-0.4234
+    pathname: L/LE/LEONT/Module-Build-0.4234.tar.gz
+    provides:
+      Module::Build 0.4234
+      Module::Build::Base 0.4234
+      Module::Build::Compat 0.4234
+      Module::Build::Config 0.4234
+      Module::Build::Cookbook 0.4234
+      Module::Build::Dumper 0.4234
+      Module::Build::Notes 0.4234
+      Module::Build::PPMMaker 0.4234
+      Module::Build::Platform::Default 0.4234
+      Module::Build::Platform::MacOS 0.4234
+      Module::Build::Platform::Unix 0.4234
+      Module::Build::Platform::VMS 0.4234
+      Module::Build::Platform::VOS 0.4234
+      Module::Build::Platform::Windows 0.4234
+      Module::Build::Platform::aix 0.4234
+      Module::Build::Platform::cygwin 0.4234
+      Module::Build::Platform::darwin 0.4234
+      Module::Build::Platform::os2 0.4234
+      Module::Build::PodParser 0.4234
+    requirements:
+      CPAN::Meta 2.142060
+      Cwd 0
+      Data::Dumper 0
+      ExtUtils::CBuilder 0.27
+      ExtUtils::Install 0
+      ExtUtils::Manifest 0
+      ExtUtils::Mkbootstrap 0
+      ExtUtils::ParseXS 2.21
+      File::Basename 0
+      File::Compare 0
+      File::Copy 0
+      File::Find 0
+      File::Path 0
+      File::Spec 0.82
+      Getopt::Long 0
+      Module::Metadata 1.000002
+      Perl::OSType 1
+      TAP::Harness 3.29
+      Text::Abbrev 0
+      Text::ParseWords 0
+      perl 5.006001
+      version 0.87
+  Module-Build-Tiny-0.048
+    pathname: L/LE/LEONT/Module-Build-Tiny-0.048.tar.gz
+    provides:
+      Module::Build::Tiny 0.048
+    requirements:
+      CPAN::Meta 0
+      CPAN::Requirements::Dynamic 0
+      DynaLoader 0
+      Exporter 5.57
+      ExtUtils::CBuilder 0
+      ExtUtils::Config 0.003
+      ExtUtils::Helpers 0.020
+      ExtUtils::Install 0
+      ExtUtils::InstallPaths 0.002
+      ExtUtils::ParseXS 0
+      File::Basename 0
+      File::Find 0
+      File::Path 0
+      File::Spec::Functions 0
+      Getopt::Long 2.36
+      JSON::PP 2
+      Pod::Man 0
+      TAP::Harness::Env 0
+      perl 5.006
+      strict 0
+      warnings 0
+  Module-Implementation-0.09
+    pathname: D/DR/DROLSKY/Module-Implementation-0.09.tar.gz
+    provides:
+      Module::Implementation 0.09
+    requirements:
+      Carp 0
+      ExtUtils::MakeMaker 0
+      Module::Runtime 0.012
+      Try::Tiny 0
+      strict 0
+      warnings 0
+  Module-Runtime-0.016
+    pathname: Z/ZE/ZEFRAM/Module-Runtime-0.016.tar.gz
+    provides:
+      Module::Runtime 0.016
+    requirements:
+      Module::Build 0
+      Test::More 0.41
+      perl 5.006
+      strict 0
+      warnings 0
+  Net-HTTP-6.23
+    pathname: O/OA/OALDERS/Net-HTTP-6.23.tar.gz
+    provides:
+      Net::HTTP 6.23
+      Net::HTTP::Methods 6.23
+      Net::HTTP::NB 6.23
+      Net::HTTPS 6.23
+    requirements:
+      Carp 0
+      Compress::Raw::Zlib 0
+      ExtUtils::MakeMaker 0
+      IO::Socket::INET 0
+      IO::Uncompress::Gunzip 0
+      URI 0
+      base 0
+      perl 5.006002
+      strict 0
+      warnings 0
+  Package-Stash-0.40
+    pathname: E/ET/ETHER/Package-Stash-0.40.tar.gz
+    provides:
+      Package::Stash 0.40
+      Package::Stash::PP 0.40
+    requirements:
+      B 0
+      Carp 0
+      Dist::CheckConflicts 0.02
+      ExtUtils::MakeMaker 0
+      Getopt::Long 0
+      Module::Implementation 0.06
+      Package::Stash::XS 0.26
+      Scalar::Util 0
+      Symbol 0
+      Text::ParseWords 0
+      constant 0
+      perl 5.008001
+      strict 0
+      warnings 0
+  Package-Stash-XS-0.30
+    pathname: E/ET/ETHER/Package-Stash-XS-0.30.tar.gz
+    provides:
+      Package::Stash::XS 0.30
+    requirements:
+      ExtUtils::MakeMaker 0
+      XSLoader 0
+      perl 5.008001
+      strict 0
+      warnings 0
+  Params-ValidationCompiler-0.31
+    pathname: D/DR/DROLSKY/Params-ValidationCompiler-0.31.tar.gz
+    provides:
+      Params::ValidationCompiler 0.31
+      Params::ValidationCompiler::Compiler 0.31
+      Params::ValidationCompiler::Exceptions 0.31
+    requirements:
+      B 0
+      Carp 0
+      Eval::Closure 0
+      Exception::Class 0
+      Exporter 0
+      ExtUtils::MakeMaker 0
+      List::Util 1.29
+      Scalar::Util 0
+      overload 0
+      strict 0
+      warnings 0
+  Readonly-2.05
+    pathname: S/SA/SANKO/Readonly-2.05.tar.gz
+    provides:
+      Readonly 2.05
+      Readonly::Array undef
+      Readonly::Hash undef
+      Readonly::Scalar undef
+    requirements:
+      Module::Build::Tiny 0.035
+      perl 5.005
+  Role-Tiny-2.002004
+    pathname: H/HA/HAARG/Role-Tiny-2.002004.tar.gz
+    provides:
+      Role::Tiny 2.002004
+      Role::Tiny::With 2.002004
+    requirements:
+      Exporter 5.57
+      perl 5.006
+  Specio-0.48
+    pathname: D/DR/DROLSKY/Specio-0.48.tar.gz
+    provides:
+      Specio 0.48
+      Specio::Coercion 0.48
+      Specio::Constraint::AnyCan 0.48
+      Specio::Constraint::AnyDoes 0.48
+      Specio::Constraint::AnyIsa 0.48
+      Specio::Constraint::Enum 0.48
+      Specio::Constraint::Intersection 0.48
+      Specio::Constraint::ObjectCan 0.48
+      Specio::Constraint::ObjectDoes 0.48
+      Specio::Constraint::ObjectIsa 0.48
+      Specio::Constraint::Parameterizable 0.48
+      Specio::Constraint::Parameterized 0.48
+      Specio::Constraint::Role::CanType 0.48
+      Specio::Constraint::Role::DoesType 0.48
+      Specio::Constraint::Role::Interface 0.48
+      Specio::Constraint::Role::IsaType 0.48
+      Specio::Constraint::Simple 0.48
+      Specio::Constraint::Structurable 0.48
+      Specio::Constraint::Structured 0.48
+      Specio::Constraint::Union 0.48
+      Specio::Declare 0.48
+      Specio::DeclaredAt 0.48
+      Specio::Exception 0.48
+      Specio::Exporter 0.48
+      Specio::Helpers 0.48
+      Specio::Library::Builtins 0.48
+      Specio::Library::Numeric 0.48
+      Specio::Library::Perl 0.48
+      Specio::Library::String 0.48
+      Specio::Library::Structured 0.48
+      Specio::Library::Structured::Dict 0.48
+      Specio::Library::Structured::Map 0.48
+      Specio::Library::Structured::Tuple 0.48
+      Specio::OO 0.48
+      Specio::PartialDump 0.48
+      Specio::Registry 0.48
+      Specio::Role::Inlinable 0.48
+      Specio::Subs 0.48
+      Specio::TypeChecks 0.48
+      Test::Specio 0.48
+    requirements:
+      B 0
+      Carp 0
+      Devel::StackTrace 0
+      Eval::Closure 0
+      Exporter 0
+      ExtUtils::MakeMaker 0
+      IO::File 0
+      List::Util 1.33
+      MRO::Compat 0
+      Module::Runtime 0
+      Role::Tiny 1.003003
+      Role::Tiny::With 0
+      Scalar::Util 0
+      Storable 0
+      Sub::Quote 0
+      Test::Fatal 0
+      Test::More 0.96
+      Try::Tiny 0
+      XString 0
+      overload 0
+      parent 0
+      perl 5.008
+      re 0
+      strict 0
+      version 0.83
+      warnings 0
+  Sub-Exporter-Progressive-0.001013
+    pathname: F/FR/FREW/Sub-Exporter-Progressive-0.001013.tar.gz
+    provides:
+      Sub::Exporter::Progressive 0.001013
+    requirements:
+      ExtUtils::MakeMaker 0
+  Sub-Identify-0.14
+    pathname: R/RG/RGARCIA/Sub-Identify-0.14.tar.gz
+    provides:
+      Sub::Identify 0.14
+    requirements:
+      ExtUtils::MakeMaker 0
+      Test::More 0
+  Sub-Quote-2.006008
+    pathname: H/HA/HAARG/Sub-Quote-2.006008.tar.gz
+    provides:
+      Sub::Defer 2.006008
+      Sub::Quote 2.006008
+    requirements:
+      ExtUtils::MakeMaker 0
+      Scalar::Util 0
+      perl 5.006
+  Sub-Uplevel-0.2800
+    pathname: D/DA/DAGOLDEN/Sub-Uplevel-0.2800.tar.gz
+    provides:
+      Sub::Uplevel 0.2800
+    requirements:
+      Carp 0
+      ExtUtils::MakeMaker 6.17
+      constant 0
+      perl 5.006
+      strict 0
+      warnings 0
+  Syntax-Keyword-Try-0.29
+    pathname: P/PE/PEVANS/Syntax-Keyword-Try-0.29.tar.gz
+    provides:
+      Syntax::Keyword::Try 0.29
+      Syntax::Keyword::Try::Deparse 0.29
+    requirements:
+      ExtUtils::CBuilder 0
+      Module::Build 0.4004
+      XS::Parse::Keyword 0.06
+      XS::Parse::Keyword::Builder 0.06
+      perl 5.014
+  Template-Toolkit-3.101
+    pathname: A/AB/ABW/Template-Toolkit-3.101.tar.gz
+    provides:
+      Template 3.101
+      Template::Base 3.100
+      Template::Config 3.100
+      Template::Constants 3.100
+      Template::Context 3.100
+      Template::Directive 3.100
+      Template::Document 3.100
+      Template::Exception 3.100
+      Template::Filters 3.100
+      Template::Grammar 3.100
+      Template::Iterator 3.100
+      Template::Monad::Assert 3.100
+      Template::Monad::Scalar 3.100
+      Template::Namespace::Constants 3.100
+      Template::Parser 3.100
+      Template::Perl 3.100
+      Template::Plugin 3.100
+      Template::Plugin::Assert 3.100
+      Template::Plugin::Datafile 3.100
+      Template::Plugin::Date 3.100
+      Template::Plugin::Date::Calc 3.100
+      Template::Plugin::Date::Manip 3.100
+      Template::Plugin::Directory 3.100
+      Template::Plugin::Dumper 3.100
+      Template::Plugin::File 3.100
+      Template::Plugin::Filter 3.100
+      Template::Plugin::Format 3.100
+      Template::Plugin::HTML 3.100
+      Template::Plugin::Image 3.100
+      Template::Plugin::Iterator 3.100
+      Template::Plugin::Math 3.100
+      Template::Plugin::Pod 3.100
+      Template::Plugin::Procedural 3.100
+      Template::Plugin::Scalar 3.100
+      Template::Plugin::String 3.100
+      Template::Plugin::Table 3.100
+      Template::Plugin::URL 3.100
+      Template::Plugin::View 3.100
+      Template::Plugin::Wrap 3.100
+      Template::Plugins 3.100
+      Template::Provider 3.100
+      Template::Service 3.100
+      Template::Stash 3.100
+      Template::Stash::Context 3.100
+      Template::Stash::XS undef
+      Template::Test 3.100
+      Template::TieString 3.100
+      Template::Toolkit 3.100
+      Template::VMethods 3.100
+      Template::View 3.100
+    requirements:
+      AppConfig 1.56
+      ExtUtils::MakeMaker 0
+      File::Spec 0.8
+      File::Temp 0.12
+      Scalar::Util 0
+  Test-Exception-0.43
+    pathname: E/EX/EXODIST/Test-Exception-0.43.tar.gz
+    provides:
+      Test::Exception 0.43
+    requirements:
+      Carp 0
+      Exporter 0
+      ExtUtils::MakeMaker 0
+      Sub::Uplevel 0.18
+      Test::Builder 0.7
+      Test::Builder::Tester 1.07
+      Test::Harness 2.03
+      base 0
+      perl 5.006001
+      strict 0
+      warnings 0
+  Test-Fatal-0.017
+    pathname: R/RJ/RJBS/Test-Fatal-0.017.tar.gz
+    provides:
+      Test::Fatal 0.017
+    requirements:
+      Carp 0
+      Exporter 5.57
+      ExtUtils::MakeMaker 6.78
+      Test::Builder 0
+      Try::Tiny 0.07
+      strict 0
+      warnings 0
+  Test-Pod-Links-0.003
+    pathname: S/SK/SKIRMESS/Test-Pod-Links-0.003.tar.gz
+    provides:
+      Test::Pod::Links 0.003
+    requirements:
+      Carp 0
+      ExtUtils::MakeMaker 0
+      HTTP::Tiny 0.014
+      Pod::Simple::Search 0
+      Pod::Simple::SimpleTree 0
+      Scalar::Util 0
+      Test::Builder 0
+      Test::XTFiles 0
+      perl 5.006
+      strict 0
+      warnings 0
+  Test-Without-Module-0.21
+    pathname: C/CO/CORION/Test-Without-Module-0.21.tar.gz
+    provides:
+      Test::Without::Module 0.21
+    requirements:
+      Carp 0
+      ExtUtils::MakeMaker 0
+      File::Find 0
+      File::Spec 0
+      Test::More 0
+  TimeDate-2.33
+    pathname: A/AT/ATOOMIC/TimeDate-2.33.tar.gz
+    provides:
+      Date::Format 2.24
+      Date::Format::Generic 2.24
+      Date::Language 1.10
+      Date::Language::Afar 0.99
+      Date::Language::Amharic 1.00
+      Date::Language::Austrian 1.01
+      Date::Language::Brazilian 1.01
+      Date::Language::Bulgarian 1.01
+      Date::Language::Chinese 1.00
+      Date::Language::Chinese_GB 1.01
+      Date::Language::Czech 1.01
+      Date::Language::Danish 1.01
+      Date::Language::Dutch 1.02
+      Date::Language::English 1.01
+      Date::Language::Finnish 1.01
+      Date::Language::French 1.04
+      Date::Language::Gedeo 0.99
+      Date::Language::German 1.02
+      Date::Language::Greek 1.00
+      Date::Language::Hungarian 1.01
+      Date::Language::Icelandic 1.01
+      Date::Language::Italian 1.01
+      Date::Language::Norwegian 1.01
+      Date::Language::Occitan 1.04
+      Date::Language::Oromo 0.99
+      Date::Language::Romanian 1.01
+      Date::Language::Russian 1.01
+      Date::Language::Russian_cp1251 1.01
+      Date::Language::Russian_koi8r 1.01
+      Date::Language::Sidama 0.99
+      Date::Language::Somali 0.99
+      Date::Language::Spanish 1.00
+      Date::Language::Swedish 1.01
+      Date::Language::Tigrinya 1.00
+      Date::Language::TigrinyaEritrean 1.00
+      Date::Language::TigrinyaEthiopian 1.00
+      Date::Language::Turkish 1.0
+      Date::Parse 2.33
+      Time::Zone 2.24
+      TimeDate 1.21
+    requirements:
+      ExtUtils::MakeMaker 0
+  Try-Tiny-0.31
+    pathname: E/ET/ETHER/Try-Tiny-0.31.tar.gz
+    provides:
+      Try::Tiny 0.31
+    requirements:
+      Carp 0
+      Exporter 5.57
+      ExtUtils::MakeMaker 0
+      constant 0
+      perl 5.006
+      strict 0
+      warnings 0
+  URI-5.28
+    pathname: O/OA/OALDERS/URI-5.28.tar.gz
+    provides:
+      URI 5.28
+      URI::Escape 5.28
+      URI::Heuristic 5.28
+      URI::IRI 5.28
+      URI::QueryParam 5.28
+      URI::Split 5.28
+      URI::URL 5.28
+      URI::WithBase 5.28
+      URI::data 5.28
+      URI::file 5.28
+      URI::file::Base 5.28
+      URI::file::FAT 5.28
+      URI::file::Mac 5.28
+      URI::file::OS2 5.28
+      URI::file::QNX 5.28
+      URI::file::Unix 5.28
+      URI::file::Win32 5.28
+      URI::ftp 5.28
+      URI::geo 5.28
+      URI::gopher 5.28
+      URI::http 5.28
+      URI::https 5.28
+      URI::icap 5.28
+      URI::icaps 5.28
+      URI::ldap 5.28
+      URI::ldapi 5.28
+      URI::ldaps 5.28
+      URI::mailto 5.28
+      URI::mms 5.28
+      URI::news 5.28
+      URI::nntp 5.28
+      URI::nntps 5.28
+      URI::pop 5.28
+      URI::rlogin 5.28
+      URI::rsync 5.28
+      URI::rtsp 5.28
+      URI::rtspu 5.28
+      URI::sftp 5.28
+      URI::sip 5.28
+      URI::sips 5.28
+      URI::snews 5.28
+      URI::ssh 5.28
+      URI::telnet 5.28
+      URI::tn3270 5.28
+      URI::urn 5.28
+      URI::urn::isbn 5.28
+      URI::urn::oid 5.28
+    requirements:
+      Carp 0
+      Cwd 0
+      Data::Dumper 0
+      Encode 0
+      Exporter 5.57
+      ExtUtils::MakeMaker 0
+      MIME::Base64 2
+      Net::Domain 0
+      Scalar::Util 0
+      constant 0
+      integer 0
+      overload 0
+      parent 0
+      perl 5.008001
+      strict 0
+      utf8 0
+      warnings 0
+  Variable-Magic-0.64
+    pathname: V/VP/VPIT/Variable-Magic-0.64.tar.gz
+    provides:
+      Variable::Magic 0.64
+    requirements:
+      Carp 0
+      Config 0
+      Exporter 0
+      ExtUtils::MakeMaker 0
+      IO::Handle 0
+      IO::Select 0
+      IPC::Open3 0
+      POSIX 0
+      Socket 0
+      Test::More 0
+      XSLoader 0
+      base 0
+      lib 0
+      perl 5.008
+  WWW-RobotRules-6.02
+    pathname: G/GA/GAAS/WWW-RobotRules-6.02.tar.gz
+    provides:
+      WWW::RobotRules 6.02
+      WWW::RobotRules::AnyDBM_File 6.00
+      WWW::RobotRules::InCore 6.02
+    requirements:
+      AnyDBM_File 0
+      ExtUtils::MakeMaker 0
+      Fcntl 0
+      URI 1.10
+      perl 5.008001
+  XML-NamespaceSupport-1.12
+    pathname: P/PE/PERIGRIN/XML-NamespaceSupport-1.12.tar.gz
+    provides:
+      XML::NamespaceSupport 1.12
+    requirements:
+      ExtUtils::MakeMaker 6.17
+      constant 0
+      perl 5.006
+      strict 0
+      vars 0
+      warnings 0
+  XML-Parser-2.47
+    pathname: T/TO/TODDR/XML-Parser-2.47.tar.gz
+    provides:
+      XML::Parser 2.47
+      XML::Parser::Expat 2.47
+      XML::Parser::Style::Debug undef
+      XML::Parser::Style::Objects undef
+      XML::Parser::Style::Stream undef
+      XML::Parser::Style::Subs undef
+      XML::Parser::Style::Tree undef
+    requirements:
+      ExtUtils::MakeMaker 0
+      LWP::UserAgent 0
+      perl 5.004050
+  XML-SAX-1.02
+    pathname: G/GR/GRANTM/XML-SAX-1.02.tar.gz
+    provides:
+      XML::SAX 1.02
+      XML::SAX::DocumentLocator undef
+      XML::SAX::ParserFactory 1.02
+      XML::SAX::PurePerl 1.02
+      XML::SAX::PurePerl::DebugHandler undef
+      XML::SAX::PurePerl::Exception undef
+      XML::SAX::PurePerl::Productions undef
+      XML::SAX::PurePerl::Reader undef
+      XML::SAX::PurePerl::Reader::Stream undef
+      XML::SAX::PurePerl::Reader::String undef
+      XML::SAX::PurePerl::Reader::URI undef
+    requirements:
+      ExtUtils::MakeMaker 0
+      File::Temp 0
+      XML::NamespaceSupport 0.03
+      XML::SAX::Base 1.05
+  XML-SAX-Base-1.09
+    pathname: G/GR/GRANTM/XML-SAX-Base-1.09.tar.gz
+    provides:
+      XML::SAX::Base 1.09
+      XML::SAX::Base::NoHandler 1.09
+      XML::SAX::Exception 1.09
+    requirements:
+      ExtUtils::MakeMaker 0
+      perl 5.008
+  XML-SAX-Expat-0.51
+    pathname: B/BJ/BJOERN/XML-SAX-Expat-0.51.tar.gz
+    provides:
+      XML::SAX::Expat 0.51
+    requirements:
+      ExtUtils::MakeMaker 0
+      XML::NamespaceSupport 0.03
+      XML::Parser 2.27
+      XML::SAX 0.03
+      XML::SAX::Base 1.00
+  XML-Simple-2.25
+    pathname: G/GR/GRANTM/XML-Simple-2.25.tar.gz
+    provides:
+      XML::Simple 2.25
+    requirements:
+      ExtUtils::MakeMaker 0
+      XML::NamespaceSupport 1.04
+      XML::SAX 0.15
+      XML::SAX::Expat 0
+      perl 5.008
+  XS-Parse-Keyword-0.42
+    pathname: P/PE/PEVANS/XS-Parse-Keyword-0.42.tar.gz
+    provides:
+      XS::Parse::Infix 0.42
+      XS::Parse::Infix::Builder 0.42
+      XS::Parse::Keyword 0.42
+      XS::Parse::Keyword::Builder 0.42
+    requirements:
+      ExtUtils::CBuilder 0
+      ExtUtils::CChecker 0.11
+      ExtUtils::ParseXS 3.16
+      Module::Build 0.4004
+      perl 5.014
+  XString-0.005
+    pathname: A/AT/ATOOMIC/XString-0.005.tar.gz
+    provides:
+      XString 0.005
+    requirements:
+      ExtUtils::MakeMaker 0
+      perl 5.008
+  XT-Files-0.002
+    pathname: S/SK/SKIRMESS/XT-Files-0.002.tar.gz
+    provides:
+      Test::XTFiles 0.002
+      XT::Files 0.002
+      XT::Files::File 0.002
+      XT::Files::Plugin 0.002
+      XT::Files::Plugin::Default 0.002
+      XT::Files::Plugin::Dirs 0.002
+      XT::Files::Plugin::Excludes 0.002
+      XT::Files::Plugin::Files 0.002
+      XT::Files::Plugin::lib 0.002
+      XT::Files::Role::Logger 0.002
+    requirements:
+      Carp 0
+      Class::Tiny 1
+      Cwd 0
+      ExtUtils::MakeMaker 0
+      File::Basename 0
+      File::Find 0
+      Module::Load 0
+      Role::Tiny 0
+      Role::Tiny::With 0
+      Scalar::Util 0
+      Test::Builder 0
+      constant 0
+      lib 0
+      overload 0
+      parent 0
+      perl 5.006
+      strict 0
+      version 0.77
+      warnings 0
+  YAML-1.31
+    pathname: I/IN/INGY/YAML-1.31.tar.gz
+    provides:
+      YAML 1.31
+      YAML::Any 1.31
+      YAML::Dumper undef
+      YAML::Dumper::Base undef
+      YAML::Error undef
+      YAML::Loader undef
+      YAML::Loader::Base undef
+      YAML::Marshall undef
+      YAML::Mo undef
+      YAML::Node undef
+      YAML::Tag undef
+      YAML::Type::blessed undef
+      YAML::Type::code undef
+      YAML::Type::glob undef
+      YAML::Type::ref undef
+      YAML::Type::regexp undef
+      YAML::Type::undef undef
+      YAML::Types undef
+      YAML::Warning undef
+      yaml_mapping undef
+      yaml_scalar undef
+      yaml_sequence undef
+    requirements:
+      ExtUtils::MakeMaker 0
+      perl 5.008001
+  libwww-perl-6.77
+    pathname: O/OA/OALDERS/libwww-perl-6.77.tar.gz
+    provides:
+      LWP 6.77
+      LWP::Authen::Basic 6.77
+      LWP::Authen::Digest 6.77
+      LWP::Authen::Ntlm 6.77
+      LWP::ConnCache 6.77
+      LWP::Debug 6.77
+      LWP::Debug::TraceHTTP 6.77
+      LWP::DebugFile 6.77
+      LWP::MemberMixin 6.77
+      LWP::Protocol 6.77
+      LWP::Protocol::cpan 6.77
+      LWP::Protocol::data 6.77
+      LWP::Protocol::file 6.77
+      LWP::Protocol::ftp 6.77
+      LWP::Protocol::gopher 6.77
+      LWP::Protocol::http 6.77
+      LWP::Protocol::loopback 6.77
+      LWP::Protocol::mailto 6.77
+      LWP::Protocol::nntp 6.77
+      LWP::Protocol::nogo 6.77
+      LWP::RobotUA 6.77
+      LWP::Simple 6.77
+      LWP::UserAgent 6.77
+    requirements:
+      Digest::MD5 0
+      Encode 2.12
+      Encode::Locale 0
+      ExtUtils::MakeMaker 0
+      File::Copy 0
+      File::Listing 6
+      File::Temp 0
+      Getopt::Long 0
+      HTML::Entities 0
+      HTML::HeadParser 3.71
+      HTTP::Cookies 6
+      HTTP::Date 6
+      HTTP::Negotiate 6
+      HTTP::Request 6.18
+      HTTP::Request::Common 6.18
+      HTTP::Response 6.18
+      HTTP::Status 6.18
+      IO::Select 0
+      IO::Socket 0
+      LWP::MediaTypes 6
+      MIME::Base64 2.1
+      Module::Load 0
+      Net::FTP 2.58
+      Net::HTTP 6.18
+      Scalar::Util 0
+      Try::Tiny 0
+      URI 1.10
+      URI::Escape 0
+      WWW::RobotRules 6
+      parent 0.217
+      perl 5.008001
+      strict 0
+      warnings 0
+  namespace-autoclean-0.29
+    pathname: E/ET/ETHER/namespace-autoclean-0.29.tar.gz
+    provides:
+      namespace::autoclean 0.29
+    requirements:
+      B::Hooks::EndOfScope 0.12
+      ExtUtils::MakeMaker 0
+      List::Util 0
+      Sub::Identify 0
+      namespace::clean 0.20
+      perl 5.006
+      strict 0
+      warnings 0
+  namespace-clean-0.27
+    pathname: R/RI/RIBASUSHI/namespace-clean-0.27.tar.gz
+    provides:
+      namespace::clean 0.27
+    requirements:
+      B::Hooks::EndOfScope 0.12
+      ExtUtils::MakeMaker 0
+      Package::Stash 0.23
+      perl 5.008001

--- a/dist.ini
+++ b/dist.ini
@@ -50,40 +50,6 @@ critic_config = t/perlcriticrc
 [Test::Compile]
 fail_on_warning = none
 
-; REF: https://metacpan.org/pod/Dist::Zilla::Plugin::Meta::Contributors
-[Meta::Contributors]
-contributor = Alejandro Imass
-contributor = Alexander Klink
-contributor = Andrew O'Brien
-contributor = Chris Brown
-contributor = Danny Sadinoff
-contributor = Dietmar Hanisch
-contributor = dtikhonov
-contributor = Erik Huelsmann
-contributor = Heiko Schlittermann
-contributor = Ivan Paponov
-contributor = Jim Brandt
-contributor = Jim Smith
-contributor = Jonas B. (jonasbn) 
-contributor = Martin Bartosch
-contributor = Martin Winkler
-contributor = Michael Bell
-contributor = Michael Roberts
-contributor = Michael Schwern
-contributor = Michiel W. Beijen
-contributor = Mohammad S Anwar
-contributor = Oliver Welter
-contributor = Petr Pisar
-contributor = Randal Schwartz
-contributor = Robert Stockdale
-contributor = Sergei Vyshenski
-contributor = Sérgio Alves
-contributor = Slaven Rezić
-contributor = Steven van der Vegt
-contributor = Thomas Erskine
-contributor = Tina Müller (tinita)
-contributor = Tom Moertel
-
 ; REF: Dist::Zilla::Plugin::Test::CPAN::Changes: https://metacpan.org/pod/Dist::Zilla::Plugin::Test::CPAN::Changes
 ; [Test::CPAN::Changes]
 

--- a/dist.ini
+++ b/dist.ini
@@ -50,6 +50,40 @@ critic_config = t/perlcriticrc
 [Test::Compile]
 fail_on_warning = none
 
+; REF: https://metacpan.org/pod/Dist::Zilla::Plugin::Meta::Contributors
+[Meta::Contributors]
+contributor = Alejandro Imass
+contributor = Alexander Klink
+contributor = Andrew O'Brien
+contributor = Chris Brown
+contributor = Danny Sadinoff
+contributor = Dietmar Hanisch
+contributor = dtikhonov
+contributor = Erik Huelsmann
+contributor = Heiko Schlittermann
+contributor = Ivan Paponov
+contributor = Jim Brandt
+contributor = Jim Smith
+contributor = Jonas B. (jonasbn) 
+contributor = Martin Bartosch
+contributor = Martin Winkler
+contributor = Michael Bell
+contributor = Michael Roberts
+contributor = Michael Schwern
+contributor = Michiel W. Beijen
+contributor = Mohammad S Anwar
+contributor = Oliver Welter
+contributor = Petr Pisar
+contributor = Randal Schwartz
+contributor = Robert Stockdale
+contributor = Sergei Vyshenski
+contributor = Sérgio Alves
+contributor = Slaven Rezić
+contributor = Steven van der Vegt
+contributor = Thomas Erskine
+contributor = Tina Müller (tinita)
+contributor = Tom Moertel
+
 ; REF: Dist::Zilla::Plugin::Test::CPAN::Changes: https://metacpan.org/pod/Dist::Zilla::Plugin::Test::CPAN::Changes
 ; [Test::CPAN::Changes]
 
@@ -67,4 +101,3 @@ meta_noindex    = 1    ;optional flag
 
 ; REF: https://metacpan.org/pod/Dist::Zilla::Plugin::Prereqs::FromCPANfile
 [Prereqs::FromCPANfile]
-

--- a/lib/Workflow/Condition.pm
+++ b/lib/Workflow/Condition.pm
@@ -2,6 +2,7 @@ package Workflow::Condition;
 
 use warnings;
 use strict;
+
 use parent qw( Workflow::Base );
 use v5.14.0;
 use Carp qw(croak);
@@ -26,7 +27,6 @@ sub evaluate {
     my ($self) = @_;
     croak "Class ", ref($self), " must implement 'evaluate()'!\n";
 }
-
 
 sub evaluate_condition {
     my ( $class, $wf, $condition_name) = @_;
@@ -82,31 +82,6 @@ sub evaluate_condition {
         return $return_value;
     }
 }
-
-package Workflow::Condition::Result;
-use parent qw( Class::Accessor );
-
-use overload '""' => 'to_string';
-
-__PACKAGE__->mk_accessors('message');
-
-sub new {
-    my ( $class, @params ) = @_;
-    my $self = bless { }, $class;
-    $self->message( shift @params ) if (@params);
-    return $self;
-}
-
-sub to_string {
-    my $self = shift;
-    return $self->message() || '<no message>';
-}
-
-package Workflow::Condition::IsTrue;
-use base 'Workflow::Condition::Result';
-
-package Workflow::Condition::IsFalse;
-use base 'Workflow::Condition::Result';
 
 1;
 
@@ -331,11 +306,21 @@ value here. If a condition returns zero or an undefined value, but
 did not throw an exception, we consider it to be '1'. Otherwise, we
 consider it to be the value returned.
 
+=head1 SEE ALSO
 
+=over
+
+=item * L<Workflow::Base>
+
+=item * L<Log::Any>
+
+=item * L<Workflow::Exception>
+
+=back
 
 =head1 COPYRIGHT
 
-Copyright (c) 2003-2021 Chris Winters. All rights reserved.
+Copyright (c) 2003-2024 Chris Winters. All rights reserved.
 
 This library is free software; you can redistribute it and/or modify
 it under the same terms as Perl itself.

--- a/lib/Workflow/Condition.pm
+++ b/lib/Workflow/Condition.pm
@@ -8,6 +8,8 @@ use v5.14.0;
 use Carp qw(croak);
 use Log::Any qw( $log );
 use Workflow::Exception qw( workflow_error );
+use Workflow::Condition::IsFalse;
+use Workflow::Condition::IsTrue;
 
 $Workflow::Condition::CACHE_RESULTS = 1;
 $Workflow::Condition::VERSION = '2.01';

--- a/lib/Workflow/Condition/IsFalse.pm
+++ b/lib/Workflow/Condition/IsFalse.pm
@@ -1,0 +1,59 @@
+package Workflow::Condition::IsFalse;
+
+use warnings;
+use strict;
+
+use parent qw(Workflow::Condition::Result);
+
+$Workflow::Condition::IsFalse = '2.01';
+
+1;
+
+__END__
+
+=pod
+
+=head1 NAME
+
+Workflow::Condition::IsTrue - helper class for false conditions
+
+=head1 VERSION
+
+This documentation describes version 2.01 of this package
+
+=head1 SYNOPSIS
+
+    if (ref $result eq 'Workflow::Condition::IsFalse') {
+        ...
+    }
+
+=head1 DESCRIPTION
+
+This is a helper class, based on L<Workflow::Condition::Result>.
+
+=head1 SEE ALSO
+
+=over
+
+=item * L<Workflow::Condition>
+
+=item * L<Workflow::Condition::Result>
+
+=item * L<Workflow::Condition::IsTrue>
+
+=back
+
+=head1 COPYRIGHT
+
+Copyright (c) 2004-2024 Chris Winters. All rights reserved.
+
+This library is free software; you can redistribute it and/or modify
+it under the same terms as Perl itself.
+
+Please see the F<LICENSE>
+
+=head1 AUTHORS
+
+Please see L<Workflow>
+
+=cut

--- a/lib/Workflow/Condition/IsTrue.pm
+++ b/lib/Workflow/Condition/IsTrue.pm
@@ -1,0 +1,59 @@
+package Workflow::Condition::IsTrue;
+
+use warnings;
+use strict;
+
+use parent qw(Workflow::Condition::Result);
+
+$Workflow::Condition::IsTrue = '2.01';
+
+1;
+
+__END__
+
+=pod
+
+=head1 NAME
+
+Workflow::Condition::IsTrue - helper class for true conditions
+
+=head1 VERSION
+
+This documentation describes version 2.01 of this package
+
+=head1 SYNOPSIS
+
+    if (ref $result eq 'Workflow::Condition::IsTrue') {
+        ...
+    }
+
+=head1 DESCRIPTION
+
+This is a helper class, based on L<Workflow::Condition::Result>.
+
+=head1 SEE ALSO
+
+=over
+
+=item * L<Workflow::Condition>
+
+=item * L<Workflow::Condition::Result>
+
+=item * L<Workflow::Condition::IsFalse>
+
+=back
+
+=head1 COPYRIGHT
+
+Copyright (c) 2004-2024 Chris Winters. All rights reserved.
+
+This library is free software; you can redistribute it and/or modify
+it under the same terms as Perl itself.
+
+Please see the F<LICENSE>
+
+=head1 AUTHORS
+
+Please see L<Workflow>
+
+=cut

--- a/lib/Workflow/Condition/Result.pm
+++ b/lib/Workflow/Condition/Result.pm
@@ -47,6 +47,14 @@ This documentation describes version 2.01 of this package
 
 Base class for condition results L<Workflow::Condition::IsTrue> and L<Workflow::Condition::IsFalse>.
 
+=head1 METHODS
+
+=head2 Class Methods
+
+=head3 to_string
+
+Returns the message of the result object or the string '<no message>' if no message is set.
+
 =head1 SEE ALSO
 
 =over

--- a/lib/Workflow/Condition/Result.pm
+++ b/lib/Workflow/Condition/Result.pm
@@ -1,0 +1,75 @@
+package Workflow::Condition::Result;
+
+use warnings;
+use strict;
+
+use parent qw( Class::Accessor );
+
+use overload '""' => 'to_string';
+
+__PACKAGE__->mk_accessors('message');
+
+$Workflow::Condition::Result = '2.01';
+
+sub new {
+    my ( $class, @params ) = @_;
+    my $self = bless { }, $class;
+    $self->message( shift @params ) if (@params);
+    return $self;
+}
+
+sub to_string {
+    my $self = shift;
+    return $self->message() || '<no message>';
+}
+
+1;
+
+__END__
+
+=pod
+
+=head1 NAME
+
+Workflow::Condition::Result - Base class for condition results isTrue and isFalse
+
+=head1 VERSION
+
+This documentation describes version 2.01 of this package
+
+=head1 SYNOPSIS
+
+    package Workflow::Condition::IsFalse;
+
+    use parent qw(Workflow::Condition::Result);
+
+=head1 DESCRIPTION
+
+Base class for condition results L<Workflow::Condition::IsTrue> and L<Workflow::Condition::IsFalse>.
+
+=head1 SEE ALSO
+
+=over
+
+=item * L<Workflow::Condition>
+
+=item * L<Workflow::Condition::IsTrue>
+
+=item * L<Workflow::Condition::IsFalse>
+
+=back
+
+=head1 COPYRIGHT
+
+Copyright (c) 2004-2024 Chris Winters. All rights reserved.
+
+This library is free software; you can redistribute it and/or modify
+it under the same terms as Perl itself.
+
+Please see the F<LICENSE>
+
+=head1 AUTHORS
+
+Please see L<Workflow>
+
+=cut


### PR DESCRIPTION
# Description

When running: `dzil build`, the following warning/error can be observed.

```
[MetaProvides::Package] 3 provide map entries did not map to .pm files and may not be loadable at install time: Workflow::Condition::IsFalse, Workflow::Condition::IsTrue, Workflow::Condition::Result
```

This is described in #236 

The 3 embedded packages have been separated into 3 separate files.

Fixes/addresses (If applicable) #236

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project, please see the [contribution guidelines](https://github.com/jonasbn/perl-workflow/blob/master/CONTRIBUTING.md).
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
