### PR TITLE
Improved specification of contributors

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -59,6 +59,40 @@ fail_on_warning = none
 ; REF: Dist::Zilla::Plugin::Test::CPAN::Meta::JSON: https://metacpan.org/pod/Dist::Zilla::Plugin::Test::CPAN::Meta::JSON
 [Test::CPAN::Meta::JSON]
 
+; REF: https://metacpan.org/pod/Dist::Zilla::Plugin::Meta::Contributors
+[Meta::Contributors]
+contributor = Alejandro Imass
+contributor = Alexander Klink
+contributor = Andrew O'Brien
+contributor = Chris Brown
+contributor = Danny Sadinoff
+contributor = Dietmar Hanisch
+contributor = dtikhonov
+contributor = Erik Huelsmann
+contributor = Heiko Schlittermann
+contributor = Ivan Paponov
+contributor = Jim Brandt
+contributor = Jim Smith
+contributor = Jonas B. (jonasbn) 
+contributor = Martin Bartosch
+contributor = Martin Winkler
+contributor = Michael Bell
+contributor = Michael Roberts
+contributor = Michael Schwern
+contributor = Michiel W. Beijen
+contributor = Mohammad S Anwar
+contributor = Oliver Welter
+contributor = Petr Pisar
+contributor = Randal Schwartz
+contributor = Robert Stockdale
+contributor = Sergei Vyshenski
+contributor = Sérgio Alves
+contributor = Slaven Rezić
+contributor = Steven van der Vegt
+contributor = Thomas Erskine
+contributor = Tina Müller (tinita)
+contributor = Tom Moertel
+
 ; REF: Dist::Zilla::Plugin::MetaProvides::Package : https://metacpan.org/pod/Dist::Zilla::Plugin::MetaProvides::Package
 [MetaProvides::Package]
 inherit_version = 0    ;optional flag


### PR DESCRIPTION
# Description

Added automatic inclusion of contributors in meta data via Dist::Zilla (specified in `dist.ini`)

This does introduce the use of an extra Dist::Zilla plugin.

I have performed a manually test of inspecting the meta-data files for a build before and after the change.

## Type of change

- [X] Minor enhancement

# Checklist:

- [X] My code follows the style guidelines of this project, please see the [contribution guidelines](https://github.com/jonasbn/perl-workflow/blob/master/CONTRIBUTING.md).
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes

