### PR TITLE
Fix STRICT_BOOLEANS = 0

### DIFF
--- a/lib/Workflow/Condition.pm
+++ b/lib/Workflow/Condition.pm
@@ -65,14 +65,14 @@ sub evaluate_condition {
 
         my $return_value;
         my $result = $condition->evaluate($wf);
-        if (ref $result eq 'Workflow::Condition::IsTrue'
+        if (ref $result eq 'Workflow::Condition::IsFalse'
+                 or (not $Workflow::Condition::STRICT_BOOLEANS and not $result)) {
+            $log->info( "Got false result with '$result' on '$orig_condition'");
+            $return_value = 0;
+        } elsif (ref $result eq 'Workflow::Condition::IsTrue'
             or (not $Workflow::Condition::STRICT_BOOLEANS and $result)) {
             $log->info( "Got true result with '$result' on '$orig_condition'");
             $return_value = 1;
-        } elsif (ref $result eq 'Workflow::Condition::IsFalse'
-                 or not $Workflow::Condition::STRICT_BOOLEANS) {
-            $log->info( "Got false result with '$result' on '$orig_condition'");
-            $return_value = 0;
         } else {
             $log->fatal( "Evaluate on '$orig_condition' did not return a valid result object" );
             $log->trace( 'Eval result', { result => $result } );

--- a/t/strict-booleans.t
+++ b/t/strict-booleans.t
@@ -1,0 +1,77 @@
+#!/usr/bin/env perl
+
+use strict;
+use lib qw(t);
+use File::Path            qw( rmtree );
+use File::Spec::Functions qw( catdir curdir rel2abs );
+use Test::More  tests => 12;
+use Test::Exception;
+
+use Workflow::Context;
+use Workflow::Factory qw( FACTORY );
+use Workflow::Persister::File;
+
+$Workflow::Condition::STRICT_BOOLEANS = 0;
+
+
+my $persist_dir = catdir( rel2abs( curdir() ), 'tmp_file' );
+unless ( -d $persist_dir ) {
+    mkdir( $persist_dir, 0777 );
+}
+
+
+FACTORY()->add_config(
+   action => [ { name => 'run', class => 'Workflow::Action::Null' } ],
+   condition => [ { name => 'HasUser', class => 'TestApp::Condition::HasUserType' } ],
+   persister => [ { name => 'Test', class => 'Workflow::Persister::File', path => $persist_dir  } ],
+   workflow => {
+      'type' => 'test',
+      'persister' => 'Test',
+      'description' => '',
+      'state' => [
+          { name => 'INITIAL',
+            action => [ { name => 'run', resulting_state => 'INITIAL',
+                          condition => [ { name => 'HasUser' },
+                                         { name => '!HasUser' }
+	                  ],
+                        },
+                      ],
+          },
+      ],
+   }
+   );
+
+my $wf;
+my $wf_state;
+my $has_user;
+my $not_has_user;
+{
+  local $Workflow::Condition::STRICT_BOOLEANS = 1;
+  $wf = FACTORY->create_workflow( 'test' );
+  dies_ok { Workflow::Condition->evaluate_condition( $wf, 'HasUser' ) },
+     qr/did not return a valid result object/;
+  dies_ok { Workflow::Condition->evaluate_condition( $wf, '!HasUser' ) },
+     qr/did not return a valid result object/;
+
+  $wf = FACTORY->create_workflow( 'test', Workflow::Context->new( current_user => 'me' ) );
+  is(Workflow::Condition->evaluate_condition( $wf, 'HasUser' ), 1, 'strict bools/User/hasUser');
+  is(Workflow::Condition->evaluate_condition( $wf, '!HasUser' ), 0, 'strict bools/User/!hasUser');
+}
+
+{
+  local $Workflow::Condition::STRICT_BOOLEANS = 0;
+  $wf = FACTORY->create_workflow( 'test' );
+  lives_ok { is( Workflow::Condition->evaluate_condition( $wf, 'HasUser' ), 0, 'loose bools/noUser/hasUser') };
+  lives_ok { is( Workflow::Condition->evaluate_condition( $wf, '!HasUser' ), 1, 'loose bools/noUser/!hasUser') };
+
+  $wf = FACTORY->create_workflow( 'test', Workflow::Context->new( current_user => 'me' ) );
+  lives_ok { is( Workflow::Condition->evaluate_condition( $wf, 'HasUser' ), 1, 'loose bools/User/hasUser') };
+  lives_ok { is( Workflow::Condition->evaluate_condition( $wf, '!HasUser' ), 0, 'loose bools/User/!hasUser') };
+}
+
+
+END {
+    if ( -d $persist_dir ) {
+        rmtree( $persist_dir );
+    }
+}


### PR DESCRIPTION
# Description

By checking the false condition before the true condition, the IsFalse object won't be interpreted as a true-ish value in case of STRICT_BOOLEANS = 0.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project, please see the [contribution guidelines](https://github.com/jonasbn/perl-workflow/blob/master/CONTRIBUTING.md).
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

