### PR TITLE
Inline conditions need to be evaluated by instance, not name

### DIFF
--- a/lib/Workflow.pm
+++ b/lib/Workflow.pm
@@ -80,14 +80,14 @@ sub context {
 
 sub get_current_actions {
     my ( $self, $group ) = @_;
-    $self->log->debug( "Getting current actions for wf '", $self->id, "'" );
+    $self->log->debug( "Getting current actions for wf '" . $self->id . "'" );
     my $wf_state = $self->_get_workflow_state;
     return $wf_state->get_available_action_names( $self, $group );
 }
 
 sub get_all_actions {
     my ( $self ) = @_;
-    $self->log->debug( "Getting all actions for wf '", $self->id, "'" );
+    $self->log->debug( "Getting all actions for wf '" . $self->id . "'" );
     my $wf_state = $self->_get_workflow_state;
     return $wf_state->get_all_action_names( $self );
 }

--- a/lib/Workflow/State.pm
+++ b/lib/Workflow/State.pm
@@ -95,7 +95,7 @@ sub evaluate_action {
     my @conditions = $self->get_conditions($action_name);
     foreach my $condition (@conditions) {
         my $condition_name = $condition->name;
-        my $rv = Workflow::Condition->evaluate_condition($wf, $condition_name);
+        my $rv = Workflow::Condition->evaluate_condition($wf, $condition);
         if (! $rv) {
 
             $self->log->is_debug


### PR DESCRIPTION
# Description

Inline conditions need to be evaluated by instance, not name because their names don't exist in the global repository of named conditions...

Fixes #244

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project, please see the [contribution guidelines](https://github.com/jonasbn/perl-workflow/blob/master/CONTRIBUTING.md).
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

I have tested the fix(es) with the example app which was used to find these issues in the first place.