### PR TITLE
Fix ExtraData persister failing to return extra data

### DIFF
--- a/lib/Workflow/Persister/DBI/ExtraData.pm
+++ b/lib/Workflow/Persister/DBI/ExtraData.pm
@@ -50,7 +50,7 @@ sub init {
 sub fetch_workflow {
     my ( $self, $wf_id ) = @_;
     my $wf_info = $self->SUPER::fetch_workflow( $wf_id );
-    my $context = $wf_info->{context} // {};
+    my $context = ($wf_info->{context} //= {});
 
     $self->log->debug( "Fetching extra workflow data for '", $wf_id, "'" );
 

--- a/lib/Workflow/Persister/DBI/ExtraData.pm
+++ b/lib/Workflow/Persister/DBI/ExtraData.pm
@@ -82,17 +82,17 @@ sub fetch_workflow {
         foreach my $i ( 0 .. $#{$data_field} ) {
             $context->{$data_field->[$i]} = $row->[$i];
             $self->log->info(
-                sub { sprintf "Set data from %s.%s into context key %s ok",
-                          $self->table, $data_field->[$i],
-                          $data_field->[$i] } );
+                sprintf( "Set data from %s.%s into context key %s ok",
+                         $self->table, $data_field->[$i],
+                         $data_field->[$i] ) );
         }
     } else {
         my $value = $row->[0];
         $context->{ $self->context_key } = $value;
         $self->log->info(
-            sub { sprintf "Set data from %s.%s into context key %s ok",
-                      $self->table, $self->data_field,
-                      $self->context_key } );
+            sprintf( "Set data from %s.%s into context key %s ok",
+                     $self->table, $self->data_field,
+                     $self->context_key ) );
     }
 
     return $wf_info;


### PR DESCRIPTION
# Description

Fix ExtraData persister failing to return extra data when the parent persister didn't already allocate a context hash.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project, please see the [contribution guidelines](https://github.com/jonasbn/perl-workflow/blob/master/CONTRIBUTING.md).
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

