### PR TITLE
Deprecate xml simple config

### DIFF
--- a/lib/Workflow.pm
+++ b/lib/Workflow.pm
@@ -427,86 +427,104 @@ This documentation describes version 2.05 of Workflow
  use Workflow::Factory qw( FACTORY );
 
  # Defines a workflow of type 'myworkflow'
- my $workflow_conf  = 'workflow.xml';
+ my $workflow_conf  = 'workflow.yaml';
 
- # contents of 'workflow.xml'
+ # contents of 'workflow.yaml'
+ type: myworkflow
+ time_zone: local                                       # optional
+ description: |-                                        # optional
+    This is my workflow.
+ history_class: My::Workflow::History                   # optional
+ state:
+ - name: INITIAL
+   action:
+   - name: "upload file"
+     resulting_state: uploaded
+ - name: uploaded
+   autorun: yes
+   action:
+   - name: "verify file"
+     resulting_state: "verified file"
+     condition:
+     - test: "$context->{user} ne 'CWINTERS'"
+   - name: "null"
+     resulting_state: annotated
+     condition:
+     - test: "$context->{user} eq 'CWINTERS'"
+ - name: "verified file"
+   action:
+   - name: annotate
+     condition:
+     - name: can_annotate
+   - name: "null"
+     condition:
+     - name: "!can_annotate"
+ - name: annotated
+   autorun: yes
+   may_stop: yes
+   action:
+   - name: "null"
+     resulting_state: finished
+     condition:
+     - name: completed
+ - name: completed
 
- <workflow>
-     <type>myworkflow</type>
-     <time_zone>local</time_zone>                         <!-- optional -->
-     <description>This is my workflow.</description>      <!-- optional -->
-     <history_class>My::Workflow::History</history_class> <!-- optional -->
+ # end of workflow.yaml
 
-     <state name="INITIAL">
-         <action name="upload file" resulting_state="uploaded" />
-     </state>
-     <state name="uploaded" autorun="yes">
-         <action name="verify file" resulting_state="verified file">
-              <!-- everyone other than 'CWINTERS' must verify -->
-              <condition test="$context->{user} ne 'CWINTERS'" />
-         </action>
-         <action name="null" resulting_state="annotated">
-              <condition test="$context->{user} eq 'CWINTERS'" />
-         </action>
-     </state>
-     <state name="verified file">
-         <action name="annotate">
-             <condition name="can_annotate" />
-         </action>
-         <action name="null">
-             <condition name="!can_annotate" />
-         </action>
-     </state>
-     <state name="annotated" autorun="yes" may_stop="yes">
-         <action name="null" resulting_state="finished">
-            <condition name="completed" />
-         </action>
-     </state>
-     <state name="finished" />
- </workflow>
 
  # Defines actions available to the workflow
- my $action_conf    = 'action.xml';
+ my $action_conf    = 'action.yaml';
 
- # contents of 'action.xml'
+ # contents of 'action.yaml'
 
- <actions>
-     <action name="upload file" class="MyApp::Action::Upload">
-         <field name="path" label="File Path"
-                description="Path to file" is_required="yes" />
-     </action>
+ action:
+ - name: "upload file"
+   class: MyApp::Action::Upload
+   field:
+   - name: path
+     label: "File Path"
+     is_required: yes
+     description: |-
+       Path to file
+ - name: "verify file"
+   class: MyApp::Action::Verify
+   validator:
+   - name: filesize_cap
+     value: "$file_size"
+ - name: annotate
+   class: MyApp::Action::Annotate
+ - name: "null"
+   class: Workflow::Action::Null
 
-     <action name="verify file" class="MyApp::Action::Verify">
-         <validator name="filesize_cap">
-             <arg>$file_size</arg>
-         </validator>
-     </action>
+ # end of action.yaml
 
-     <action name="annotate"    class="MyApp::Action::Annotate" />
-
-     <action name="null"        class="Workflow::Action::Null" />
- </actions>
 
  # Defines conditions available to the workflow
- my $condition_conf = 'condition.xml';
+ my $condition_conf = 'condition.yaml';
 
- # contents of 'condition.xml'
+ # contents of 'condition.yaml'
 
- <conditions>
-     <condition name="can_annotate"
-                class="MyApp::Condition::CanAnnotate" />
- </conditions>
+ condition:
+ - name: can_annotate
+   class: MyApp::Condition::CanAnnotate
+
+ # end of condition.yaml
+
 
  # Defines validators available to the actions
- my $validator_conf = 'validator.xml';
+ my $validator_conf = 'validator.yaml';
 
- # contents of 'validator.xml'
+ # contents of 'validator.yaml'
 
- <validators>
-     <validator name="filesize_cap" class="MyApp::Validator::FileSizeCap">
-         <param name="max_size" value="20M" />
-     </validator>
- </validators>
+ validator:
+ - name: filesize_cap
+   class: MyApp::Validator::FileSizeCap
+   param:
+   - name: max_size
+     value: 20M
+
+ # end of 'validator.yaml'
+
 
  # Stock the factory with the configurations; we can add more later if
  # we want

--- a/lib/Workflow/Action.pm
+++ b/lib/Workflow/Action.pm
@@ -173,18 +173,22 @@ This documentation describes version 2.05 of this package
 
 =head1 SYNOPSIS
 
- # Configure the Action...
- <action name="CreateUser"
-         class="MyApp::Action::CreateUser">
-   <field name="username" is_required="yes"/>
-   <field name="email" is_required="yes"/>
-   <validator name="IsUniqueUser">
-       <arg>$username</arg>
-   </validator>
-   <validator name="IsValidEmail">
-       <arg>$email</arg>
-   </validator>
- </action>
+ # Configure the action... (in e.g., 'actions.yaml')
+ action:
+ - name: CreateUser
+   class: MyApp::Action::CreateUser
+   field:
+   - name: username
+     is_required: yes
+   - name: email
+     is_required: yes
+   validator:
+   - name: IsUniqueUser
+     arg:
+     - value: '$username'
+   - name: IsValidEmail
+     arg:
+     - value: '$email'
 
  # Define the action
 
@@ -245,15 +249,15 @@ You can specify a type in your actions configuration to associate that action
 with that workflow type. If you don't provide a type, the action is available
 to all types. For example:
 
-  <actions>
-    <type>Ticket</type>
-    <description>Actions for the Ticket workflow only.</description>
-    <action name="TIX_NEW"
-            group="some_action_group"
-            class="TestApp::Action::TicketCreate">
-       <description>My action description</description> <!-- optional -->
-       <!-- the 'group' attribute is optional -->
-  ...Addtional configuration...
+  type: Ticket                                          <-- here!
+  description: |-
+    Actions for the Ticket workflow only.
+  action:
+  - name: TIX_NEW
+    group: some_action_group                             # optional
+    class: TestApp::Action::TicketCreate
+    description: |-                                      # optional
+      My action description
 
 The type must match an existing workflow type or the action will never
 be called.
@@ -351,27 +355,33 @@ an example on how you easily do this by overriding new():
 
 1) Set the less changing properties in your action definition:
 
-  <actions>
-    <type>foo</type>
-    <action name="Browse"
-      type="menu_button" icon="list_icon"
-      class="actual::action::class">
-    </action>
+  type: foo
+  action:
+  - name: Browse
+    type: menu_button
+    icon: list_icon
+    class: actual::action::class
 
 2) Set the state dependant properties in the state definition:
 
- <state name="INITIAL">
-   <description>
-     Manage Manufaturers
-   </description>
-   <action index="0" name="Browse" resulting_state="BROWSE">
-     <condition name="roleis_oem_mgmt"/>
-   </action>
-   <action index="1" name="Create" resulting_state="CREATE">
-     <condition name="roleis_oem_mgmt"/>
-   </action>
-   <action index="2" name="Back" resulting_state="CLOSED"/>
- </state>
+ state:
+ - name: INITIAL
+   description: |-
+     Manage Manufacturers
+   action:
+   - name: Browse
+     index: '0'
+     resulting_state: BROWSE
+     condition:
+     - name: roleis_oem_mgmt
+   - name: Create
+     index: '1'
+     resulting_state: CREATE
+     condition:
+     - name: roleis_oem_mgmt
+   - name: Back
+     index: '2'
+     resulting_state: CLOSED
 
 3) Craft a custom action base class
 

--- a/lib/Workflow/Action/Null.pm
+++ b/lib/Workflow/Action/Null.pm
@@ -28,13 +28,17 @@ This documentation describes version 2.05 of this package
 
 =head1 SYNOPSIS
 
- # in workflow.xml...
- <state name="some state">
-   <action name="null" />
-   ...
+ # in workflow.yaml...
+ state:
+   name: 'some state'
+   action:
+   - name: 'null'
+ ...
 
- # in workflow_action.xml...
- <action name="null" class="Workflow::Action::Null" />
+ # in workflow_action.yaml...
+ action:
+ - name: 'null'
+   class: Workflow::Action::Null
 
 =head1 DESCRIPTION
 
@@ -43,14 +47,18 @@ modules out there, it does nothing with a purpose! For instance, you
 might want some poor slobs to have some action verified but the elite
 masters can skip the work entirely. So you can do:
 
-  <state name="checking" autorun="yes">
-     <action name="verify" resulting_state="verified">
-         <condition name="isPoorSlob" />
-     </action>
-     <action name="null" resulting_state="verified">
-         <condition name="isEliteMaster" />
-     </action>
-  </state>
+  state:
+  - name: checking
+    autorun: yes
+    action:
+    - name: verify
+      resulting_state: verified
+      condition:
+      - name: isPoorSlob
+    - name: 'null'
+      resulting_state: verified
+      condition:
+      - name: isEliteMaster
 
 =head1 OBJECT METHODS
 

--- a/lib/Workflow/Condition.pm
+++ b/lib/Workflow/Condition.pm
@@ -102,36 +102,31 @@ This documentation describes version 2.05 of this package
 
 =head1 SYNOPSIS
 
- # First declare the condition in a 'workflow_condition.xml'...
+ # First declare the condition in a 'workflow_condition.yaml'...
 
- <conditions>
-   <condition
-      name="IsAdminUser"
-      class="MyApp::Condition::IsAdminUser">
-         <param name="admin_group_id" value="5" />
-         <param name="admin_group_id" value="6" />
-   </condition>
- ...
+ condition:
+ - name: IsAdminUser
+   class: MyApp::Condition::IsAdminUser
+   param:
+   - name: admin_group_id
+     value: '5'
+   - name: admin_group_id
+     value: '6'
 
  # Reference the condition in an action of the state/workflow definition...
- <workflow>
-   <state>
-     ...
-     <action name="SomeAdminAction">
-       ...
-       <condition name="IsAdminUser" />
-     </action>
-     <action name="AnotherAdminAction">
-      ...
-      <condition name="IsAdminUser" />
-     </action>
-     <action name="AUserAction">
-      ...
-      <condition name="!IsAdminUser" />
-     </action>
-   </state>
+ state:
+ - name: SomeAdminAction
    ...
- </workflow>
+   condition:
+   - name: IsAdminUser
+ - name: AnotherAdminAction
+   ...
+   condition:
+   - name: IsAdminUser
+ - name: AUserAction
+   ...
+   condition:
+   - name: !IsAdminUser
 
  # Then implement the condition
 
@@ -192,15 +187,15 @@ for both.
 
 You can accomplish this by adding a type in the condition configuration.
 
- <conditions>
- <type>Ticket</type>
-   <condition
-      name="IsAdminUser"
-      class="MyApp::Condition::IsAdminUser">
-         <param name="admin_group_id" value="5" />
-         <param name="admin_group_id" value="6" />
-   </condition>
- ...
+ type: Ticket
+ condition:
+ - name: IsAdminUser
+   class: MyApp::Condition::IsAdminUser
+   param:
+   - name: admin_group_id
+     value: '5'
+   - name: admin_group_id
+     value: '6'
 
 The type must match a loaded workflow type, or the condition won't work.
 When the workflow looks for a condition, it will look for a typed condition

--- a/lib/Workflow/Condition/Evaluate.pm
+++ b/lib/Workflow/Condition/Evaluate.pm
@@ -68,9 +68,12 @@ This documentation describes version 2.05 of this package
 
 =head1 SYNOPSIS
 
- <state name="foo">
-     <action name="foo action">
-         <condition test="$context->{foo} =~ /^Pita chips$/" />
+ state:
+ - name: foo
+   action:
+   - name: 'foo action'
+     condition:
+     - test: "$context->{foo} =~ /^Pita chips$/"
 
 =head1 DESCRIPTION
 
@@ -80,15 +83,17 @@ specifying a condition class. We differentiate by the 'test' attribute
 
 While it's easy to abuse something like this with:
 
- <condition>
-   <test><![CDATA[
-     if ( $context->{foo} =~ /^Pita (chips|snacks|bread)$/" ) {
-          return $context->{bar} eq 'hummus';
-     }
-     else { ... }
-     ]]>
-   </test>
- </condition>
+
+ state:
+ - name: foo
+   action:
+   - name: 'foo action'
+     condition:
+     - test: |-
+       if ( $context->{foo} =~ /^Pita (chips|snacks|bread)$/" ) {
+            return $context->{bar} eq 'hummus';
+       }
+       else { ... }
 
 It should provide a good balance.
 
@@ -109,9 +114,12 @@ We use L<Safe> to provide a restricted compartment in which we
 evaluate the text. This should prevent any sneaky bastards from doing
 something like:
 
- <state...>
-     <action...>
-         <condition test="system( 'rm -rf /' )" />
+ state:
+ ...
+ - action:
+   ...
+   - condition:
+     - test: "system( 'rm -rf /' )"
 
 The text has access to one variable, for the moment:
 

--- a/lib/Workflow/Condition/HasUser.pm
+++ b/lib/Workflow/Condition/HasUser.pm
@@ -48,20 +48,22 @@ This documentation describes version 2.05 of this package
 
  # First setup the condition
 
- <conditions>
-   <condition name="HasUser"
-              class="Workflow::Condition::HasUser">
-     <param name="user_key" value="CurrentUser" />
-   </condition>
-   ...
+ condition:
+ - name: HasUser
+   class: Workflow::Condition::HasUser
+   param:
+   - name: user_key
+     value: CurrentUser
 
  # Next, attach it to an action
 
- <state name="INITIAL">
-   <action name="create issue"
-           resulting_state="CREATED">
-       <condition name="CurrentUser" />
-   </action>
+ state:
+ - name: INITIAL
+   action:
+   - name: 'create issue'
+     resulting_state: CREATED
+     condition:
+     - name: CurrentUser
    ...
 
  # Whenever you fetch available actions from state 'INITIAL' you must

--- a/lib/Workflow/Condition/LazyAND.pm
+++ b/lib/Workflow/Condition/LazyAND.pm
@@ -69,48 +69,65 @@ further evaluation is aborted and I<false> is returned.
 
 =head1 SYNOPSIS
 
-In condition.xml:
+In condition.yaml:
 
-    <condition name="cond1" ... />
-    <condition name="cond2" ... />
-    <condition name="cond3" ... />
+  condition:
+  - name: cond1
+    ...
+  - name: cond2
+    ...
+  - name cond3
+    ...
+  - name: check_prereqs
+    class: Workflow::Condition::LazyAND
+    param:
+    - name: condition
+      value: cond1
+    - name: condition
+      value: cond2
+    - name: condition
+      value: cond3
 
-    <condition name="check_prereqs" class="Workflow::Condition::LazyAND">
-        <param name="condition" value="cond1" />
-        <param name="condition" value="cond2" />
-        <param name="condition" value="cond3" />
-    </condition>
+In workflow.yaml:
 
-In workflow.xml:
-
-    <state name="CHECK_PREREQS" autorun="yes">
-        <action name="null_1" resulting_state="HAVE_PREREQS">
-            <condition name="check_prereqs" />
-        </action>
-        <action name="null_2" resulting_state="FAILURE">
-            <condition name="!check_prereqs" />
-        </action>
-    </state>
+  state:
+  - name: CHECK_PREREQS
+    autorun: yes
+    action:
+    - name: null_1
+      resulting_state: HAVE_PREREQS
+      condition:
+      - name: check_prereqs
+    - name: null_2
+      resulting_state: FAILURE
+      condition:
+      - name: !check_prereqs
 
 =cut
 
 =head1 PARAMETERS
 
-The following parameters may be configured in the C<param> entity of the
-condition in the XML configuration:
+The following parameters may be configured in the C<param> key of the
+condition in the YAML configuration:
 
 =head2 condition, conditionN
 
 The condition parameter may be specified as either a list of repeating
 entries B<or> with a unique integer appended to the I<condition> string:
 
-    <param name="condition" value="first_condition_to_test" />
-    <param name="condition" value="second_condition_to_test" />
+  param:
+  - name: condition
+    value: first_condition_to_test
+  - name: condition
+    value: second_condition_to_test
 
 B<or>
 
-    <param name="condition1" value="first_condition_to_test" />
-    <param name="condition2" value="second_condition_to_test" />
+  param:
+  - name: condition1
+    value: first_condition_to_test
+  - name: condition2
+    value: second_condition_to_test
 
 =head1 COPYRIGHT
 

--- a/lib/Workflow/Condition/LazyOR.pm
+++ b/lib/Workflow/Condition/LazyOR.pm
@@ -66,48 +66,65 @@ I<false>, LazyOR also returns I<false>.
 
 =head1 SYNOPSIS
 
-In condition.xml:
+In condition.yaml:
 
-    <condition name="cond1" ... />
-    <condition name="cond2" ... />
-    <condition name="cond3" ... />
+  condition:
+  - name: cond1
+    ...
+  - name: cond2
+    ...
+  - name cond3
+    ...
+  - name: check_prereqs
+    class: Workflow::Condition::LazyOR
+    param:
+    - name: condition
+      value: cond1
+    - name: condition
+      value: cond2
+    - name: condition
+      value: cond3
 
-    <condition name="check_prereqs" class="Workflow::Condition::LazyOR">
-        <param name="condition" value="cond1" />
-        <param name="condition" value="cond2" />
-        <param name="condition" value="cond3" />
-    </condition>
+In workflow.yaml:
 
-In workflow.xml:
-
-    <state name="CHECK_PREREQS" autorun="yes">
-        <action name="null_1" resulting_state="HAVE_PREREQS">
-            <condition name="check_prereqs" />
-        </action>
-        <action name="null_2" resulting_state="FAILURE">
-            <condition name="!check_prereqs" />
-        </action>
-    </state>
+  state:
+  - name: CHECK_PREREQS
+    autorun: yes
+    action:
+    - name: null_1
+      resulting_state: HAVE_PREREQS
+      condition:
+      - name: check_prereqs
+    - name: null_2
+      resulting_state: FAILURE
+      condition:
+      - name: !check_prereqs
 
 =cut
 
 =head1 PARAMETERS
 
 The following parameters may be configured in the C<param> entity of the
-condition in the XML configuration:
+condition in the YAML configuration:
 
 =head2 condition, conditionN
 
 The condition parameter may be specified as either a list of repeating
 entries B<or> with a unique integer appended to the I<condition> string:
 
-    <param name="condition" value="first_condition_to_test" />
-    <param name="condition" value="second_condition_to_test" />
+  param:
+  - name: condition
+    value: first_condition_to_test
+  - name: condition
+    value: second_condition_to_test
 
 B<or>
 
-    <param name="condition1" value="first_condition_to_test" />
-    <param name="condition2" value="second_condition_to_test" />
+  param:
+  - name: condition1
+    value: first_condition_to_test
+  - name: condition2
+    value: second_condition_to_test
 
 =head1 COPYRIGHT
 

--- a/lib/Workflow/Condition/Negated.pm
+++ b/lib/Workflow/Condition/Negated.pm
@@ -55,21 +55,27 @@ while false becomes true).
 
 =head1 SYNOPSIS
 
-In condition.xml:
+In condition.yaml:
 
-    <condition name="check_approvals" class="...">
-    </condition>
+  condition:
+  - name: check_approvals
+    class: ...
 
-In workflow.xml:
+In workflow.yaml:
 
-    <state name="CHECK_APPROVALS" autorun="yes">
-        <action name="null_1" resulting_state="APPROVED">
-            <condition name="check_approvals" />
-        </action>
-        <action name="null_2" resulting_state="REJECTED">
-            <condition name="!check_approvals" />
-        </action>
-    </state>
+
+  state:
+  - name: CHECK_APPROVALS
+    autorun: yes
+    condition:
+    - name: null_1
+      resulting_state: APPROVED
+      condition:
+      - name: check_approvals
+    - name: null_2
+      resulting_state: REJECTED
+      condition:
+      - name: !check_approvals
 
 =cut
 

--- a/lib/Workflow/Config.pm
+++ b/lib/Workflow/Config.pm
@@ -306,15 +306,15 @@ workflow pieces:
       description   $
       persister     $
       initial_state $
-      observer    \@
+      observer      \@
           sub           $
           class         $
-      state       \@
+      state         \@
           name          $
           description   $
           action        \@
               name            $
-              resulting_state $
+              resulting_state $ -or- \%
               condition       \@
                   name              $
 
@@ -348,6 +348,11 @@ multiple 'action' declarations
 
 each 'action' declaration holds 'name' and 'resulting_state' keys and
 may hold a 'condition' key with one or more named conditions
+
+The value of the 'resulting_state' key may either be a string (the name
+of the single next state) or a hash mapping return values of the action
+to next states. The C< * > (asterisk) is the catch-all value mapping all
+unspecified values to a single next state.
 
 =item *
 

--- a/lib/Workflow/Config/XML.pm
+++ b/lib/Workflow/Config/XML.pm
@@ -44,10 +44,20 @@ my %XML_OPTIONS = (
 );
 
 my $XML_REQUIRED = 0;
+my $warned = 0;
 
 sub parse {
     my ( $self, $type, @items ) = @_;
 
+    unless ($warned) {
+        warn $log->warning(
+            'WARNING: The use of XML configuration is deprecated; it\'s '
+            . 'based on XML::Simple, which itself is deprecated since 2012. '
+            . "Please use YAML instead.\n" );
+
+        # warn once
+        $warned = 1;
+    }
     $self->_check_config_type($type);
     my @config_items = Workflow::Config::_expand_refs(@items);
     return () unless ( scalar @config_items );
@@ -128,9 +138,17 @@ Implementation of configuration parser for XML files/data; requires
 L<XML::Simple> to be installed. See L<Workflow::Config> for C<parse()>
 description.
 
-=head2 METHODS
+=head2 Status of this module
 
-=head3 parse ( $type, @items )
+The use of XML configuration is deprecated and slated for removal in
+Workflow 3.0. Please use L<Workflow::Config::YAML> for YAML-based
+configuration instead, or write your own XML configuration module;
+see L<Workflow::Config/Creating Your Own Parser> for an explanation
+of how.
+
+=head1 METHODS
+
+=head2 parse ( $type, @items )
 
 This method parses the configuration provided it is in XML format.
 

--- a/lib/Workflow/InputField.pm
+++ b/lib/Workflow/InputField.pm
@@ -131,14 +131,16 @@ This documentation describes version 2.05 of this package
 
  # Declare the fields needed by your action in the configuration...
 
- <action name="CreateUser">
-    <field name="username"
-           is_required="yes"
-           source_class="App::Field::ValidUsers" />
-    <field name="email"
-           is_required="yes" />
-    <field name="office"
-           source_list="Pittsburgh,Hong Kong,Moscow,Portland" />
+ action:
+ - name: CreateUser
+   field:
+   - name: username
+     is_required: yes
+     source_class: App::Field::ValidUsers
+   - name: email
+     is_required: yes
+   - name: office
+     source_list: Pittsburgh,Hong Kong,Moscow,Portland
  ...
 
 =head1 DESCRIPTION
@@ -189,17 +191,21 @@ derive your own input field class (see I<class> in L</"Properties">
 below). For example, suppose you need to add extra properties to all
 your fields like "index", "disabled", etc.
 
-In your actions definition XML file, you can just add them and the
+In your actions definition YAML file, you can just add them and the
 parser will pick them up. Pay close attention the custom InputField
 "class" property.
 
-  <actions>
-    <type>foo</type>
-    <action name="Bar"
-      class="your::action::class">
-      <field index="0" name="id" type="integer" disabled="yes"
-        is_required="yes" class="your::custom::inputfieldclass"/>
-    </action>
+  type: foo
+  action:
+  - name: Bar
+    class: your::action::class
+    field:
+    - name: id
+      index: '0'
+      type: integer
+      disabled: yes
+      is_required: yes
+      class: your::custom::inputfieldclass
 
 But you need to give them life by creating the accessors for these
 extra properties. Just derive your custom fields class like so:

--- a/lib/Workflow/Persister.pm
+++ b/lib/Workflow/Persister.pm
@@ -140,23 +140,26 @@ This documentation describes version 2.05 of this package
 
 =head1 SYNOPSIS
 
- # Associate a workflow with a persister
- <workflow type="Ticket"
-           persister="MainDatabase">
+ # Associate a workflow with a persister in workflow.yaml
+ type: Ticket
+ persister: MainDatabase
+ state:
  ...
 
- # Declare a persister
- <persister name="MainDatabase"
-            class="Workflow::Persister::DBI"
-            driver="MySQL"
-            dsn="DBI:mysql:database=workflows"
-            user="wf"
-            password="mypass"/>
+ # Declare a persister in persister.yaml
+ persister:
+ - name: MainDatabase
+   class: Workflow::Persister::DBI
+   driver: MySQL
+   dsn: DBI:mysql:database=workflows
+   user: wf
+   password: mypass
 
- # Declare a separate persister
- <persister name="FileSystem"
-            class="Workflow::Persister::File"
-            path="/path/to/my/workflow"/>
+ # Declare a separate persister in other_persister.yaml
+ persister:
+ - name: FileSystem
+   class: Workflow::Persister::File
+   path: /path/to/my/workflow
 
 =head1 DESCRIPTION
 

--- a/lib/Workflow/Persister/DBI.pm
+++ b/lib/Workflow/Persister/DBI.pm
@@ -487,28 +487,26 @@ This documentation describes version 2.05 of this package
 
 =head1 SYNOPSIS
 
- <persister name="MainDatabase"
-            class="Workflow::Persister::DBI"
-            dsn="DBI:mysql:database=workflows"
-            user="wf"
-            password="mypass"/>
-
- <persister name="BackupDatabase"
-            class="Workflow::Persister::DBI"
-            dsn="DBI:Pg:dbname=workflows"
-            user="wf"
-            password="mypass"
-            date_format="%Y-%m-%d %H:%M"
-            autocommit="0"
-            workflow_table="wf"
-            workflow_sequence="wf_seq"
-            history_table="wf_history"
-            history_sequence="wf_history_seq"/>
-
- <persister name="OtherDatabase"
-            class="My::Persister::DBHFromElsewhere"
-            driver="mysql"
-            />
+ # persister.yaml
+ persister:
+ - name: MainDatabase
+   class: Workflow::Persister::DBI
+   dsn: DBI:mysql:database=workflows
+   user: wf
+   password: mypass
+ - name: BackupDatabase
+   class: Workflow::Persister::DBI
+   user: wf
+   password: mypass
+   date_format: '%Y-%m-%d %H:%M'
+   autocommit: 0
+   workflow_table: wf
+   workflow_sequence: wf_seq
+   history_table: wf_history
+   history_sequence: wf_history_seq
+ - name: OtherDatabase
+   class: My::Persester::DBHFromElsewhere
+   driver: mysql
 
 
 =head1 DESCRIPTION

--- a/lib/Workflow/Persister/DBI/AutoGeneratedId.pm
+++ b/lib/Workflow/Persister/DBI/AutoGeneratedId.pm
@@ -73,9 +73,10 @@ This documentation describes version 2.05 of this package
 
 =head1 SYNOPSIS
 
- <persister name="MyPersister"
-            dsn="DBI:mysql:database=foo"
-            ...
+ persister:
+ - name: MyPersister
+   dsn: DBI:mysql:database=foo
+   ...
 
 =head1 DESCRIPTION
 

--- a/lib/Workflow/Persister/DBI/ExtraData.pm
+++ b/lib/Workflow/Persister/DBI/ExtraData.pm
@@ -114,14 +114,15 @@ This documentation describes version 2.05 of this package
 
 =head1 SYNOPSIS
 
- <persister name="MyPersister"
-            class="Workflow::Persister::DBI::ExtraData"
-            dsn="DBI:mysql:database=workflows"
-            user="wf"
-            password="mypass"
-            extra_table="workflow_ticket"
-            extra_data_field="ticket_id"
-            extra_context_key="ticket_id"/>
+ persister:
+ - name: MyPersister
+   class: Workflow::Persister::DBI::ExtraData
+   dsn: DBI:mysql:database=workflows
+   user: wf
+   password: mypass
+   extra_table: workflow_ticket
+   extra_data_field: ticket_id
+   extra_data_context_key: ticket_id
 
 =head1 DESCRIPTION
 
@@ -138,11 +139,11 @@ the 'workflow' table.
  # Specify a single field 'ticket_id' from the table 'workflow_ticket'
  # and store it in the context using the same key:
 
- <persister
-     ...
-     extra_table="workflow_ticket"
-     extra_data_field="ticket_id"
-     ...
+ persister:
+ - name: ...
+   extra_table: workflow_ticket
+   extra_data_field: ticket_id
+   ...
 
  # How you would use this:
  my $wf = FACTORY->fetch_workflow( 'Ticket', 55 );
@@ -152,12 +153,12 @@ the 'workflow' table.
  # Specify a single field 'ticket_id' from the table 'workflow_ticket'
  # and store it in the context using a different key
 
- <persister
-     ...
-     extra_table="workflow_ticket"
-     extra_data_field="ticket_id"
-     extra_context_key="THE_TICKET_ID"
-     ...
+ persister:
+ - name: ...
+   extra_table: workflow_ticket
+   extra_data_field: ticket_id
+   extra_context_key: THE_TICKET_ID
+   ...
 
  # How you would use this:
  my $wf = FACTORY->fetch_workflow( 'Ticket', 55 );
@@ -167,11 +168,11 @@ the 'workflow' table.
  # Specify multiple fields ('ticket_id', 'last_viewer',
  # 'last_view_date') to pull from the 'workflow_ticket' table:
 
- <persister
-     ...
-     extra_table="workflow_ticket"
-     extra_data_field="ticket_id,last_viewer,last_view_date"
-     ...
+ persister:
+ - name: ...
+   extra_table: workflow_ticket
+   extra_data_field: ticket_id,last_viewer,last_view_date
+   ...
 
  # How you would use this:
  my $wf = FACTORY->fetch_workflow( 'Ticket', 55 );

--- a/lib/Workflow/Persister/DBI/SequenceId.pm
+++ b/lib/Workflow/Persister/DBI/SequenceId.pm
@@ -58,11 +58,11 @@ This documentation describes version 2.05 of this package
 
 =head1 SYNOPSIS
 
- <persister
-     name="MyPersister"
-     workflow_sequence="wf_seq"
-     history_sequence="wf_history_seq"
- ...
+ persister:
+ - name: MyPersister
+   workflow_sequence: wf_seq
+   history_sequence: wf_history_seq
+   ...
 
 =head1 DESCRIPTION
 

--- a/lib/Workflow/Persister/File.pm
+++ b/lib/Workflow/Persister/File.pm
@@ -195,9 +195,10 @@ This documentation describes version 2.05 of this package
 
 =head1 SYNOPSIS
 
- <persister name="MainPersister"
-            class="Workflow::Persister::File"
-            path="/home/workflow/storage"/>
+ persister:
+ - name: MainPersister
+   class: Workflow::Persister::File
+   path: /home/workflow/storage
 
 =head1 DESCRIPTION
 

--- a/lib/Workflow/Persister/RandomId.pm
+++ b/lib/Workflow/Persister/RandomId.pm
@@ -47,10 +47,10 @@ This documentation describes version 2.05 of this package
 
 =head1 SYNOPSIS
 
- <persister
-     name="MyPersister"
-     id_length="16"
- ...
+ persister:
+ - name: MyPersister
+   id_length: 16
+   ...
 
 =head1 DESCRIPTION
 

--- a/lib/Workflow/Persister/UUID.pm
+++ b/lib/Workflow/Persister/UUID.pm
@@ -36,10 +36,10 @@ This documentation describes version 2.05 of this package
 
 =head1 SYNOPSIS
 
- <persister
-     name="MyPersister"
-     use_uuid="yes"
- ...
+ persister:
+ - name: MyPersister
+   use_uuid: yes
+   ...
 
 =head1 DESCRIPTION
 

--- a/lib/Workflow/State.pm
+++ b/lib/Workflow/State.pm
@@ -342,23 +342,27 @@ This documentation describes version 2.05 of this package
 =head1 SYNOPSIS
 
  # This is an internal object...
- <workflow...>
-   <state name="Start">
-     <description>My state documentation</description> <!-- optional -->
-     <action ... resulting_state="Progress" />
-   </state>
-      ...
-   <state name="Progress" description="I am in progress">
-     <action ... >
-        <resulting_state return="0" state="Needs Affirmation" />
-        <resulting_state return="1" state="Approved" />
-        <resulting_state return="*" state="Needs More Info" />
-     </action>
-   </state>
-      ...
-   <state name="Approved" autorun="yes">
-     <action ... resulting_state="Completed" />
-      ...
+ state:
+ - name: Start
+   description: |-                                 # optional
+     My state documentation
+   action:
+   - ...
+     resulting_state: Progress
+ ...
+ - name: Progress
+   description: I am in progress
+   action:
+   - ...
+     resulting_state:
+       0: 'Needs Affirmation'
+       1: 'Approved'
+       *: 'Needs More Info'
+ - name: Approved
+   autorun: yes
+   action:
+   - ...
+     resulting_state: Completed
 
 =head1 DESCRIPTION
 
@@ -374,12 +378,13 @@ The resulting state is action-dependent. For instance, in the
 following example you can perform two actions from the state 'Ticket
 Created' -- 'add comment' and 'edit issue':
 
-  <state name="Ticket Created">
-     <action name="add comment"
-             resulting_state="NOCHANGE" />
-     <action name="edit issue"
-             resulting_state="Ticket In Progress" />
-   </state>
+ state:
+ - name: Ticket Created
+   action:
+   - name: add comment
+     resulting_state: NOCHANGE
+   - name: edit issue
+     resulting_state: Ticket In Progress
 
 If you execute 'add comment' the new state of the workflow will be the
 same ('NOCHANGE' is a special state). But if you execute 'edit issue'
@@ -389,13 +394,14 @@ You can also have multiple return states for a single action. The one
 chosen by the workflow system will depend on what the action
 returns. For instance we might have something like:
 
-  <state name="create user">
-     <action name="create">
-         <resulting_state return="admin"    state="Assign as Admin" />
-         <resulting_state return="helpdesk" state="Assign as Helpdesk" />
-         <resulting_state return="*"        state="Assign as Luser" />
-     </action>
-  </state>
+ state:
+ - name: create user
+   action:
+   - name: create
+     resulting_state:
+       admin: Assign as Admin
+       helpdesk: Assign as Helpdesk
+       *: Assign as Luser
 
 So if we execute 'create' the workflow will be in one of three states:
 'Assign as Admin' if the return value of the 'create' action is
@@ -409,13 +415,12 @@ first example under L</Resulting State>. The set of I<available> actions is
 a subset of all I<associated> actions: those actions for which none of the
 associated conditions fail their check.
 
-  <state name="create user">
-     <action name="create">
-         ... (resulting_states) ...
-         <condition name="can_create_users" />
-     </action>
-  </state>
-
+ state:
+ - name: create
+   resulting_state:
+     ... (resulting states) ...
+   condition:
+   - name: can_create_users
 
 
 =head2 Autorun State
@@ -437,14 +442,18 @@ workflow enters an autorun state, Workflow can't continue execution.
 If this is isn't a problem, a state may be marked with C<may_stop="yes">:
 
 
-   <state name="Approved" autorun="yes" may_stop="yes">
-     <action name="Archive" resulting_state="Completed" />
-        <condition name="allowed_automatic_archival" />
-     </action>
-  </state>
+ state:
+ - name: Approved
+   autorun: yes
+   may_stop: yes
+   action:
+   - name: Archive
+     resulting_state: Completed
+     condition:
+     - name: allowed_automatic_archival
 
 
-However, in case the state isn't marked C<may_stop="yes">, Workflow will
+However, in case the state isn't marked C<may_stop: yes>, Workflow will
 throw a C<workflow_error> indicating an autorun problem.
 
 

--- a/lib/Workflow/Validator.pm
+++ b/lib/Workflow/Validator.pm
@@ -38,27 +38,33 @@ This documentation describes version 2.05 of this package
 =head1 SYNOPSIS
 
  # First declare the validator...
- <validator name="DateValidator"
-            class="MyApp::Validator::Date">
-   <param name="date_format" value="%Y-%m-%d %h:%m"/>
- </validator>
+ validator:
+ - name: DateValidator
+   class: MyApp::Validator::Date
+   param:
+   - name: date_format
+     value: '%Y-%m-%d %H:%M'
 
  # Then associate the validator with runtime data from the context...
- <action name="MyAction">
-    <validator name="DateValidator">
-       <arg>$due_date</arg>
-    </validator>
- </action>
+ action:
+ - name: MyAction
+   validator:
+   - name: DateValidator
+     arg:
+     - '$due_date'
 
  # TODO: You can also inintialize and instantiate in one step if you
  # don't need to centralize or reuse (does this work?)
 
- <action name="MyAction">
-    <validator class="MyApp::Validator::Date">
-       <param name="date_format" value="%Y-%m-%d %h:%m"/>
-       <arg>$due_date</arg>
-    </validator>
- </action>
+ action:
+ - name: MyAction
+   validator:
+   - class: MyApp::Validator::Date
+     param:
+     - name: date_format
+       value: '%Y-%m-%d %H:%M'
+     arg:
+     - '$due_date'
 
  # Then implement the logic using your favorite object system; e.g. Moo
 

--- a/lib/Workflow/Validator/HasRequiredField.pm
+++ b/lib/Workflow/Validator/HasRequiredField.pm
@@ -40,13 +40,15 @@ This documentation describes version 2.05 of this package
 =head1 SYNOPSIS
 
  # Validator is created automatically when you mark a field as
- # 'is_required=yes' in the action, such as:
+ # 'is_required: yes' in the action, such as:
 
- <action name="CreateUser">
-    <field name="username"
-           is_required="yes"
-           source_class="App::Fied::ValidUsers"/>
-    ...
+ action:
+ - name: CreateUser
+   field:
+   - name: username
+     is_required: yes
+     source_class: App::Field::ValidUsers
+   ...
 
 =head1 DESCRIPTION
 
@@ -56,13 +58,14 @@ before the associated action is executed.
 
 for instance, given the configuration:
 
- <action name="CreateUser">
-    <field name="username"
-           is_required="yes"/>
-    <field name="email"
-           is_required="yes"/>
-    <field name="office">
- </action>
+ action:
+ - name: CreateUser
+   field:
+   - name: username
+     is_required: yes
+   - name: email
+     is_required: yes
+   - name: office
 
 An action executed with such a context:
 
@@ -77,14 +80,16 @@ Would fail with a message:
 
 You normally do not need to configure this validator yourself. It gets
 generated automatically when the Action configration is read
-in. However, if you do need to create it yourself:
+in based on the 'is_required: yes' attribute. However, if you do need
+to create it yourself:
 
- <action name='Foo'>
-    <validator name="HasRequiredField">
-       <arg value="fieldOne"/>
-       <arg value="field_two"/>
-    </validator>
- <?action>
+ action:
+ - name: Foo
+   validator:
+   - name: HasRequiredField
+     arg:
+     - fieldOne
+     - field_two
 
 Note that we do not try to match the value in the context against a
 set of known values or algorithm, just see if the value is defined --

--- a/lib/Workflow/Validator/InEnumeratedType.pm
+++ b/lib/Workflow/Validator/InEnumeratedType.pm
@@ -67,29 +67,33 @@ This documentation describes version 2.05 of this package
 
  # Inline the enumeration...
 
- <action name="PlayGame">
-   <validator name="InEnumeratedType">
-      <value>Rock</value>
-      <value>Scissors</value>
-      <value>Paper</value>
-      <arg value="$play"/>
-   </validator>
- </action>
+ action:
+ - name: PlayGame
+   validator:
+   - name: InEnumeratedType
+     value:
+     - Rock
+     - Scissors
+     - Paper
+     arg:
+     - '$play'
 
  # Or declare it in the validator to be more readable...
- <validator name="RSP"
-            class="Validator::InEnumeratedType">
-      <value>Rock</value>
-      <value>Scissors</value>
-      <value>Paper</value>
- </validator>
+ validator:
+ - name: RSP
+   class: Workflow::Validator::InEnumeratedType
+   value:
+   - Rock
+   - Scissors
+   - Paper
 
  # ...and use it in your action
- <action name="PlayGame">
-    <validator name="RSP">
-       <arg value="$play"/>
-    </validator>
- </action>
+ action:
+ - name: PlayGame
+   validator:
+   - name: RSP
+     arg:
+     - '$play'
 
 =head1 DESCRIPTION
 
@@ -123,25 +127,29 @@ powerful piece of reflection.
 
 Onto the code. First we declare a field type of 'worker':
 
- <field type="worker"
-        class="MyApp::Field::Worker"/>
+ field:
+ - type: worker
+   class: MyApp::Field::Worker
 
 Next a validator of this enumerated type:
 
- <validator name="IsWorker"
-            class="MyApp::Validator::WorkerEnumeration"/>
+ validator:
+ - name: IsWorker
+   class: MyApp::Validator::WorkerEnumeration
 
 We then associate this field type with a field in the action and the
 validator to ensure the user selects a worker from the right pool:
 
- <action name="AssignTicket">
-    <field name="assignee"
-           type="worker"
-           is_required="yes"/>
-   ...
-   <validator name="IsWorker">
-       <arg value="$assignee"/>
-   </validator>
+ action:
+ - name: AssignTicket
+   field:
+   - name: assignee
+     type: worker
+     is_required: yes
+   validator:
+   - name: IsWorker
+     arg:
+     - '$assignee'
 
 Note that the name of the field and the name used in the validator are
 the same. This allows external applications to query the action for

--- a/lib/Workflow/Validator/MatchesDateFormat.pm
+++ b/lib/Workflow/Validator/MatchesDateFormat.pm
@@ -65,12 +65,15 @@ This documentation describes version 2.05 of this package
 
 =head1 SYNOPSIS
 
- <action name="CreateNews">
-   <validator name="DateFormat">
-      <param name="date_format" value="%Y-%m-%d"/>
-      <arg value="$news_post_date"/>
-   </validator>
- </action>
+ action:
+ - name: CreateNews
+   validator:
+   - name: DateFormat
+     param:
+     - name: date_format
+       value: '%Y-%m-%d'
+     arg:
+     - '$news_post_date'
 
 =head1 DESCRIPTION
 


### PR DESCRIPTION
# Description

Deprecate XML: Warn when used and replace documentation with YAML instead of XML

Closes #125 

## Type of change

Please delete options that are not relevant.

- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project, please see the [contribution guidelines](https://github.com/jonasbn/perl-workflow/blob/master/CONTRIBUTING.md).
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
