### PR TITLE
Add back 'autorun' parameter in 'completed' event and fix docs

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -76,8 +76,8 @@
 - `Workflow` no longer calls `{commit,rollback}_transaction`; the factory has assumed this
   responsibility as it's the factory which is in charge of serializing workflows
 - `Workflow::Action->execute` must return a scalar value or undef (no references)
-- Renamed observer event `complete` to `executed`, changed arguments for `state change` an `executed`
-  observer events to be a hash a not positional arguments.
+- Renamed observer event `execute` to `completed`, changed arguments for `state change` and `completed`
+  observer events to be a hash (not positional arguments).
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -497,20 +497,18 @@ context remains in a valid state; upon successful validation, the `$args`
 are merged into the context and the action is executed as described above.
 
 After the action has been successfully executed and the workflow saved
-we issue a 'execute' observation with the old state, action name and
-an autorun flag as additional parameters.
-So if you wanted to write an observer you could create a
-method with the signature:
+we issue a 'completed' observable event with an event arguments hash as
+additional parameter. So if you wanted to write an observer you
+could create a method with the signature:
 
     sub update {
-        my ( $class, $workflow, $action, $old_state, $action_name )
-           = @_;
-        if ( $action eq 'execute' ) { .... }
+        my ( $class, $workflow, $event, $event_args ) = @_;
+        if ( event eq 'completed' ) { .... }
     }
 
-We also issue a 'change state' observation if the executed action
-resulted in a new state. See ["WORKFLOWS ARE OBSERVABLE"](#workflows-are-observable) above for how
-we use and register observers.
+We also issue a 'change state' observable event if the executed action
+resulted in a new state. See ["WORKFLOWS ARE OBSERVABLE"](#workflows-are-observable)
+above for how we use and register observers.
 
 Returns: new state of workflow
 

--- a/lib/Workflow/Factory.pm
+++ b/lib/Workflow/Factory.pm
@@ -351,13 +351,7 @@ sub create_workflow {
     $wf->notify_observers('create');
 
     my $state = $wf->_get_workflow_state();
-    if ( $state->autorun ) {
-        my $state_name = $state->state;
-        $self->log->info( "State '$state_name' marked to be run ",
-                          "automatically; executing that state/action..." );
-        my $action_name = $wf->_get_autorun_action_name( $state );
-        $wf->execute_action($action_name);
-    }
+    $wf->_maybe_autorun_state( $state );
 
     return $wf;
 }

--- a/t/factory_autorun_initial.t
+++ b/t/factory_autorun_initial.t
@@ -29,7 +29,7 @@ is_deeply( \@AutorunInitialObserver::events,
             ['startup'],
             ['run'],
             ['save'],
-            ['completed', {'action' => 'RUN', 'state' => 'INITIAL'}],
+            ['completed', {'action' => 'RUN', 'state' => 'INITIAL', 'autorun' => !!1}],
             ['state change', {'from' => 'INITIAL', 'to' => 'FINAL', 'action' => 'RUN'}],
             ['finalize']
            ],


### PR DESCRIPTION
# Description

Fix documentation. Fix 'autorun' parameter no longer present.

Fixes/addresses (If applicable) #257

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project, please see the [contribution guidelines](https://github.com/jonasbn/perl-workflow/blob/master/CONTRIBUTING.md).
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] ~~Any dependent changes have been merged and published in downstream modules~~

You might think, that this is one crazy checklist, but it is just as much written for the maintainer of the involved software :-)
