### PR TITLE
Fix regression from context parameter accessor

### DIFF
--- a/lib/Workflow/Base.pm
+++ b/lib/Workflow/Base.pm
@@ -49,10 +49,7 @@ sub param {
     }
 
     unless ( defined $value ) {
-        if ( exists $self->{PARAMS}{$name} ) {
-            return $self->{PARAMS}{$name};
-        }
-        return;
+        return $self->{PARAMS}{$name};
     }
     return $self->{PARAMS}{$name} = $value;
 }
@@ -60,7 +57,7 @@ sub param {
 sub delete_param {
     my ( $self, $name ) = @_;
     unless ( defined $name ) {
-        return;
+        return undef;
     }
 
     # Allow multiple parameters to be deleted at once...
@@ -75,12 +72,7 @@ sub delete_param {
         return {%list};
     }
 
-    if ( exists $self->{PARAMS}{$name} ) {
-        my $value = $self->{PARAMS}{$name};
-        delete $self->{PARAMS}{$name};
-        return $value;
-    }
-    return;
+    return delete $self->{PARAMS}{$name};
 }
 
 sub clear_params {

--- a/t/perlcriticrc
+++ b/t/perlcriticrc
@@ -20,7 +20,15 @@ allowed_values = 0 1 2 3 4 5 6
 # revisited with a major release, since it would break backwards compatibility, the recommeded 
 # solution is bare return
 # REF: https://metacpan.org/pod/Perl::Critic::Policy::Subroutines::ProhibitExplicitReturnUndef
-[Subroutines::ProhibitExplicitReturnUndef]
+#
+# The reverse policy also exists:
+#
+# https://metacpan.org/pod/Perl::Critic::Policy::Community::EmptyReturn
+#
+# vetted by a wide audience of Perl community; see the metacpan url and the commit where this
+# comment was added for why this policy should not be enabled in general
+#
+[-Subroutines::ProhibitExplicitReturnUndef]
 
 # The violater of this is an overwrite for Class::Accessor
 # REF: https://metacpan.org/pod/Perl::Critic::Policy::NamingConventions::ProhibitAmbiguousNames


### PR DESCRIPTION
# Description

Fix regression where non-existing context parameters lead to mis-aligned positional parameters in:

```perl
  my_func( $wf->context->param('nonexist'), $wf->context->param('exist');
```

Where the above translates into `my_func( 'yes' );` if `yes` is the value of the `exist` parameter.

Fixes/addresses (If applicable) #266 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

Even more: I'd argue it's a fix to a regression from 1.x.

# Checklist:

- [x] My code follows the style guidelines of this project, please see the [contribution guidelines](https://github.com/jonasbn/perl-workflow/blob/master/CONTRIBUTING.md).
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

I wonder about the new tests: is this a feature that needs testing, or is this a coding style issue where we simply need to settle on one over the other?