### PR TITLE
CI: replace cpm with cpanm in matrix jobs to fix Perl < 5.24 breakage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Log perl information
         run: perl -V
       - name: Install dependencies
-        run: cd build && cpm install --global Carton::Snapshot && cpm install --global --verbose --show-build-log-on-failure --with-all
+        run: cd build && cpanm --installdeps .
       - name: Run tests
         run: cd build && prove --timer --lib --recurse --jobs $(nproc) --shuffle t
 
@@ -101,7 +101,7 @@ jobs:
       - name: Log perl information
         run: perl -V
       - name: Install dependencies
-        run: cd build && cpm install --global Carton::Snapshot && cpm install --global --verbose --show-build-log-on-failure --with-all
+        run: cd build && cpanm --installdeps .
       - name: Run tests
         run: cd build && prove --timer --lib --recurse --jobs $(sysctl -n hw.logicalcpu) --shuffle t
 
@@ -123,6 +123,6 @@ jobs:
       - name: Log perl information
         run: perl -V
       - name: Install dependencies
-        run: cd build && cpm install --global Carton::Snapshot && cpm install --global --verbose --show-build-log-on-failure --with-all
+        run: cd build && cpanm --installdeps .
       - name: Run tests
         run: cd build && prove --timer --lib --recurse --jobs $(nproc) --shuffle t


### PR DESCRIPTION
## Summary

- The `cpm` binary bundled in `shogo82148/actions-setup-perl@v1` was silently updated (via the floating `@v1` tag) to require Perl ≥ 5.24, breaking the `linux 5.14` and `linux 5.20` matrix jobs with `Perl v5.24.0 required--this is only v5.20.3, stopped`.
- Replaced `cpm install --global Carton::Snapshot && cpm install --global --verbose --show-build-log-on-failure --with-all` with `cpanm --installdeps .` in the `linux`, `macos`, and `windows` jobs.
- `cpanm` is also provided by `actions-setup-perl` and has no minimum Perl version constraint. The global `PERL_CPANM_OPT: "--quiet --notest"` env var already set in the workflow applies automatically.
- The `build` job (which runs latest Perl) is unaffected and left unchanged.

## Test plan

- [ ] Verify `linux 5.14` and `linux 5.20` jobs pass in CI on this PR
- [ ] Verify `linux 5.30`, `linux 5.40`, `macos`, and `windows` jobs still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)