### PR TITLE
CI: add zizmor workflow audit and harden action security

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ on:
     branches:
       - '*'
 
+permissions:
+  contents: read
+
 env:
   PERL_CPANM_OPT: "--quiet --notest"
 
@@ -23,12 +26,14 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
       - name: Extract author information
         run: |
           echo AUTHOR_NAME="$(git log -1 ${GITHUB_REF} --pretty='%aN')" >> $GITHUB_ENV
           echo AUTHOR_EMAIL="$(git log -1 ${GITHUB_REF} --pretty='%aE')" >> $GITHUB_ENV
-      - uses: shogo82148/actions-setup-perl@v1
+      - uses: shogo82148/actions-setup-perl@a198315ec4e9244f206879ea7b63078003aec8a6 # v1
       - name: Log perl version
         run: perl -V
       - name: Install Dist::Zilla & Devel::Cover::Report::Coveralls
@@ -40,7 +45,7 @@ jobs:
       - name: Build dist
         run: dzil build --no-tgz --in build
       - name: Install dependencies
-        run: cd build && cpm install --global Carton::Snapshot && cpm install --global --verbose --with-all
+        run: cd build && cpanm --installdeps .
       - name: Run tests
         run: |
           cd build
@@ -54,7 +59,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload build results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: build_results
           path: build
@@ -67,21 +72,20 @@ jobs:
         perl: [ "5.14", "5.20", "5.30", "5.40" ]
     name: linux ${{ matrix.perl }}
 
-
     steps:
       - name: Download build results
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: build_results
           path: build
       - name: Setup Perl
-        uses: shogo82148/actions-setup-perl@v1
+        uses: shogo82148/actions-setup-perl@a198315ec4e9244f206879ea7b63078003aec8a6 # v1
         with:
           perl-version: ${{ matrix.perl }}
       - name: Log perl information
         run: perl -V
       - name: Install dependencies
-        run: cd build && cpm install --global Carton::Snapshot && cpm install --global --verbose --show-build-log-on-failure --with-all
+        run: cd build && cpanm --installdeps .
       - name: Run tests
         run: cd build && prove --timer --lib --recurse --jobs $(nproc) --shuffle t
 
@@ -92,16 +96,16 @@ jobs:
 
     steps:
       - name: Download build results
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: build_results
           path: build
       - name: Setup Perl
-        uses: shogo82148/actions-setup-perl@v1
+        uses: shogo82148/actions-setup-perl@a198315ec4e9244f206879ea7b63078003aec8a6 # v1
       - name: Log perl information
         run: perl -V
       - name: Install dependencies
-        run: cd build && cpm install --global Carton::Snapshot && cpm install --global --verbose --show-build-log-on-failure --with-all
+        run: cd build && cpanm --installdeps .
       - name: Run tests
         run: cd build && prove --timer --lib --recurse --jobs $(sysctl -n hw.logicalcpu) --shuffle t
 
@@ -112,17 +116,17 @@ jobs:
 
     steps:
       - name: Download build results
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: build_results
           path: build
       - name: Setup Perl
-        uses: shogo82148/actions-setup-perl@v1
+        uses: shogo82148/actions-setup-perl@a198315ec4e9244f206879ea7b63078003aec8a6 # v1
         with:
           distribution: strawberry
       - name: Log perl information
         run: perl -V
       - name: Install dependencies
-        run: cd build && cpm install --global Carton::Snapshot && cpm install --global --verbose --show-build-log-on-failure --with-all
+        run: cd build && cpanm --installdeps .
       - name: Run tests
         run: cd build && prove --timer --lib --recurse --jobs $(nproc) --shuffle t

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,25 @@
+name: zizmor
+
+on:
+  push:
+    branches:
+      - '*'
+    tags-ignore:
+      - '*'
+  pull_request:
+    branches:
+      - '*'
+
+permissions:
+  contents: read
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+      - name: Run zizmor
+        run: pip install zizmor && zizmor .github/workflows/

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -22,4 +22,4 @@ jobs:
         with:
           persist-credentials: false
       - name: Run zizmor
-        run: pip install zizmor && zizmor .github/workflows/
+        run: pip install zizmor==1.26.1 && zizmor .github/workflows/


### PR DESCRIPTION
## Summary

- **Add `zizmor.yml`** — runs [zizmor](https://github.com/zizmor/zizmor) (GitHub Actions static analysis) on every push/PR, installed via `pip install zizmor`
- **Pin all action SHAs** — floating tags like `@v1` silently receive updates; pinning to commit SHAs prevents surprises (this was the root cause of the recent `cpm` breakage in #283)
- **Add `permissions: contents: read`** at workflow level — restricts the implicit write access GitHub grants by default
- **Add `persist-credentials: false`** to `actions/checkout` — prevents credentials being baked into the artifact
- **Switch matrix jobs to `cpanm --installdeps .`** — also fixes the Perl < 5.24 `cpm` breakage independently of #283; if this PR is merged first, #283 can be closed

## Pinned SHAs

| Action | Tag | Commit SHA |
|--------|-----|-----------|
| `actions/checkout` | v7 | `9c091bb` |
| `actions/upload-artifact` | v7 | `043fb46` |
| `actions/download-artifact` | v8 | `3e5f45b` |
| `shogo82148/actions-setup-perl` | v1 | `a198315` (dereferenced from annotated tag) |

## Test plan

- [ ] `zizmor` job passes with "No findings to report" on this PR
- [ ] `build`, `linux`, `macos`, `windows` CI jobs all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)